### PR TITLE
docs: add PRD, architecture document, and improvement epic backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ python3 -m py_compile web/app.py worker/tasks/conversion.py worker/warmup.py
 
 | Document | Description |
 |----------|-------------|
+| [Product Requirements (PRD)](docs/PRD.md) | Product overview, personas, requirements, success metrics |
+| [Architecture](docs/ARCHITECTURE.md) | C4-style system views, data flows, security architecture, ADRs |
+| [Improvement Backlog](docs/BACKLOG.md) | Prioritized epics: conversion quality, OCR, hardening, optimization |
 | [Build Guide](BUILD.md) | GPU/CPU build profiles and deployment |
 | [API Reference](docs/API.md) | Full REST API documentation |
 | [UI Specification](docs/UI_SPECIFICATION.md) | UI elements, workflows, and state machine |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,377 @@
+# DocuFlux — Architecture Document
+
+**Status:** Current-state description · **Last updated:** 2026-06-11
+**Related docs:** [PRD.md](PRD.md) · [BACKLOG.md](BACKLOG.md) · [API.md](API.md) · [CONFIGURATION.md](CONFIGURATION.md) · [DEPLOYMENT.md](DEPLOYMENT.md) · [AI_INTEGRATION.md](AI_INTEGRATION.md)
+
+This document describes the system as it exists today, including known gaps. Planned changes are referenced by their [BACKLOG.md](BACKLOG.md) story IDs.
+
+---
+
+## 1. System Context (C4 Level 1)
+
+```mermaid
+flowchart TB
+    subgraph Actors
+        U[Browser User]
+        A[API Client / Pipeline]
+        E[Browser Extension<br/>Chrome / Firefox]
+        G[LLM Agent<br/>MCP Consumer]
+    end
+
+    DF[DocuFlux Deployment<br/>document conversion service]
+
+    subgraph External
+        S3[(S3-compatible storage<br/>optional backend)]
+        WH[Webhook Receivers]
+        MS[Model Artifact Sources<br/>Marker weights, TinyLlama GGUF<br/>build/startup only]
+        CF[Cloudflare Tunnel<br/>optional ingress]
+    end
+
+    U -->|HTTPS / WebSocket| DF
+    A -->|REST API v1 + dk_ key| DF
+    E -->|Capture API, CORS-scoped| DF
+    G -->|MCP tools| DF
+    DF -->|store/retrieve| S3
+    DF -->|POST on job completion| WH
+    MS -.->|fetched at build/startup| DF
+    CF -.->|ingress| DF
+```
+
+Trust note: all conversion and metadata extraction is local. The only runtime egress is webhook delivery (SSRF-guarded, see §6.5).
+
+---
+
+## 2. Container View (C4 Level 2)
+
+Five runtime containers plus the distributed browser extension:
+
+```mermaid
+flowchart LR
+    subgraph Docker network
+        WEB[web<br/>Flask 3.1 + eventlet<br/>SocketIO, Gunicorn<br/>:5000]
+        RED[(redis 7-alpine<br/>DB0 Celery broker<br/>DB1 job metadata, encrypted)]
+        WRK[worker<br/>Celery, pool=solo<br/>Pandoc · Marker · SLM<br/>metrics :9090]
+        BEAT[beat<br/>Celery Beat<br/>cleanup + metrics every 120s]
+        MCP[mcp-server<br/>Node.js + Playwright<br/>:8080 internal]
+    end
+    EXT[browser extension<br/>extension-src/]
+    VOL[(shared volume<br/>data/uploads · data/outputs<br/>AES-256-GCM encrypted)]
+
+    EXT -->|capture API| WEB
+    WEB <-->|broker + metadata| RED
+    WRK <-->|tasks + metadata| RED
+    BEAT --> RED
+    WRK -->|MCP_SECRET bearer| MCP
+    WEB <--> VOL
+    WRK <--> VOL
+```
+
+### 2.1 `web` — Flask application (`web/`)
+
+- Flask 3.1 with eventlet monkey-patching, Flask-SocketIO for real-time job updates, Gunicorn (eventlet worker class).
+- Route blueprints: `routes/conversion.py` (convert/status/download), `routes/capture.py` (extension sessions), `routes/auth.py` (API keys), `routes/webhooks.py`, `routes/health.py`.
+- Middleware: CSRF (Flask-WTF), rate limiting (Flask-Limiter backed by Redis), structured JSON logging with `X-Request-ID` correlation, ProxyFix behind `BEHIND_PROXY`.
+
+### 2.2 `worker` — Celery worker (`worker/`)
+
+- `pool=solo`, concurrency 1, `max_tasks_per_child=50`, `acks_late=True`, `reject_on_worker_lost=True`.
+- 11 tasks across `tasks/conversion.py`, `tasks/capture.py`, `tasks/metadata.py`, `tasks/maintenance.py`.
+- `warmup.py` detects GPU and eagerly loads the SLM; Marker models are lazy-loaded on first use (~30 s penalty — Backlog 6.2).
+- Prometheus metrics on port 9090 (`metrics.py`).
+
+### 2.3 `beat` — Celery Beat
+
+- Schedules `cleanup_old_files` and `update_metrics` every 120 s (`tasks/__init__.py`).
+
+### 2.4 `redis` — broker and metadata store
+
+- DB 0: Celery broker + result backend; DB 1: job metadata hashes (values encrypted via `shared/redis_encryption.py`), capture sessions, API keys, rate-limit counters, dead-letter queue (`dlq:tasks`).
+- `requirepass`, 256 MB `maxmemory` with `noeviction`, AOF persistence. **Known gap:** TLS is disabled pending certificate generation (Backlog 4.1); Sentinel HA supported via config.
+
+### 2.5 `mcp-server` — Playwright automation (`mcp_server/`)
+
+- Node.js HTTP server (internal port 8080) exposing browser actions; authenticated by `MCP_SECRET` bearer token; reachable only from the worker. **Known gaps:** runs as root, no container healthcheck (Backlog 4.5).
+
+### 2.6 Browser extension (`extension-src/`)
+
+- Chrome MV3 / Firefox MV2 manifests; DOMPurify for sanitization; Socket.IO client for progress; built via `scripts/build-extension.js`.
+
+### 2.7 Inter-container contracts
+
+| Contract | Definition |
+|----------|------------|
+| Celery task signatures | `tasks.convert_document`, `tasks.convert_with_marker`, `tasks.convert_with_marker_slm`, `tasks.convert_with_hybrid`, `tasks.process_capture_batch`, `tasks.assemble_capture_session`, `tasks.extract_slm_metadata`, maintenance tasks |
+| Queue routing | Marker/SLM/hybrid → `gpu` queue; Pandoc < 5 MB → `high_priority`; Pandoc ≥ 5 MB → `default` |
+| Redis key schema | `job:{uuid}` (hash), `capture:session:{uuid}`, `jobs:active`, `workers:status`, `dlq:tasks` |
+| Worker→MCP | HTTP POST `http://mcp-server:8080/execute`, `Authorization: Bearer ${MCP_SECRET}` |
+
+---
+
+## 3. Component View (C4 Level 3)
+
+### 3.1 Web components
+
+```mermaid
+flowchart TB
+    subgraph web
+        APP[app.py<br/>init, middleware, auth, CORS, CSP]
+        CONV[routes/conversion.py<br/>convert · status · download]
+        CAP[routes/capture.py<br/>session lifecycle]
+        AUTH[routes/auth.py<br/>key CRUD]
+        WHK[routes/webhooks.py]
+        HLT[routes/health.py<br/>healthz · readyz · api/health]
+        VAL[validation.py<br/>magic bytes · UUID · SSRF · filename]
+    end
+    subgraph shared
+        ENC[encryption.py<br/>AES-256-GCM]
+        STO[storage.py<br/>local FS / S3]
+        KEY[key_manager.py]
+        JMD[job_metadata.py]
+        RENC[redis_encryption.py]
+        FMT[formats.py]
+        POPT[pandoc_options.py]
+        SEC[secrets_manager.py]
+    end
+    CONV --> VAL & ENC & STO & JMD & FMT
+    CAP --> VAL & JMD
+    AUTH --> KEY
+    APP --> SEC & RENC
+```
+
+### 3.2 Worker engine selection
+
+```mermaid
+flowchart TB
+    REQ[job dequeued] --> Q{engine?}
+    Q -->|pandoc formats| P[convert_document<br/>pandoc subprocess, 500s timeout<br/>hard limit 600s]
+    Q -->|pdf_marker| M[convert_with_marker<br/>page limit check via pypdfium2<br/>PdfConverter, hard limit 1200s]
+    Q -->|pdf_marker_slm| MS[convert_with_marker_slm<br/>Marker + SLM refine in 600-word chunks<br/>hard limit 1500s]
+    Q -->|pdf_hybrid| H[convert_with_hybrid]
+    H --> HP[try Pandoc]
+    HP --> QC{quality ≥ 50 words/page?}
+    QC -->|yes| DONE[save output]
+    QC -->|no| M
+    M --> SLMQ[queue extract_slm_metadata]
+    MS --> DONE
+    P --> DONE
+    SLMQ --> DONE
+    DONE --> CLN[_cleanup_marker_memory<br/>gc + cuda empty_cache]
+```
+
+The 50-words/page heuristic (`_assess_pandoc_quality`, `worker/tasks/conversion.py`) is the system's only quality measure — Backlog 1.1/1.2 replaces it with a structured scorer.
+
+---
+
+## 4. Data Flow Views
+
+### 4.1 Standard conversion lifecycle
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant W as web (Flask)
+    participant R as Redis
+    participant K as worker
+    participant V as data/ volume
+
+    C->>W: POST /api/v1/convert (multipart)
+    W->>W: validate (magic bytes, size, disk space, rate limit)
+    W->>V: encrypt upload (AES-256-GCM)
+    W->>R: HSET job:{id} status=queued (encrypted values)
+    W->>R: enqueue Celery task (queue by engine/size)
+    W-->>C: 202 {job_id}
+    K->>R: dequeue task
+    K->>V: decrypt input
+    K->>K: convert (Pandoc / Marker / hybrid)
+    K->>V: encrypt output (+ images/)
+    K->>R: HSET status=completed, progress=100
+    R-->>W: pub/sub
+    W-->>C: SocketIO job_update
+    C->>W: GET /api/v1/download/{id}
+    W->>V: decrypt (zip if multi-file)
+    W-->>C: stream attachment
+    Note over R,V: Beat cleanup: 10 min post-download / 1 h undownloaded / 5 min failed
+```
+
+### 4.2 Browser capture assembly
+
+```mermaid
+sequenceDiagram
+    participant E as Extension
+    participant W as web
+    participant R as Redis
+    participant K as worker
+
+    E->>W: POST /capture/sessions → session_id
+    loop pages (≤500, batches of 50)
+        E->>W: POST /sessions/{id}/pages (html + screenshot b64)
+        W->>R: LPUSH session pages
+        R->>K: process_capture_batch (per 50 pages)
+        K->>K: screenshots → PDF (PIL) → Marker force_ocr
+    end
+    E->>W: POST /sessions/{id}/finish
+    W->>R: enqueue assemble_capture_session
+    K->>K: merge batch markdown + images + YAML front matter
+    K->>R: status=completed (progress 75%→100%)
+```
+
+### 4.3 Webhook delivery
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant W as web
+    participant K as worker
+    participant H as Webhook receiver
+
+    C->>W: POST /api/v1/webhooks {job_id, url}
+    W->>W: SSRF validation (IP blocklist, scheme, optional HTTPS-only)
+    K->>H: POST {job_id, status, download_url, slm_metadata}
+    Note over K,H: 3 retries on failure
+```
+
+### 4.4 Job metadata lifecycle (Redis DB 1)
+
+States: `queued → in_progress → completed | failed`. Each `job:{uuid}` hash carries status, progress (0–100), stage, filenames, formats, engine, timestamps, and (post-Marker) SLM metadata — values encrypted at rest. TTLs and the Beat sweep enforce retention; failed tasks additionally land in `dlq:tasks` for inspection.
+
+---
+
+## 5. Deployment Topologies
+
+### 5.1 Docker Compose variants
+
+| File | Purpose | Key differences |
+|------|---------|-----------------|
+| `docker-compose.yml` | Base | redis, web, worker, beat, mcp-server; hardening defaults (non-root, cap_drop ALL, no-new-privileges, noexec tmpfs) |
+| `docker-compose.gpu.yml` | GPU overlay | worker 16–18 GB memory, NVIDIA device reservation, `MARKER_ENABLED=true` |
+| `docker-compose.cpu.yml` | CPU overlay | worker 2 GB memory, Marker disabled |
+| `docker-compose.tls.yml` | Redis TLS overlay | **currently inert** — certs not generated (Backlog 4.1) |
+| `docker-compose.cloudflare.yml` | Tunnel ingress | adds cloudflared container |
+
+Build: `scripts/build.sh auto` detects GPU (`nvidia-smi`) and selects `BUILD_GPU`, which switches the worker base image (`nvidia/cuda:11.8.0-cudnn8` vs `ubuntu:22.04`) and requirements file (`requirements-gpu.txt` ~15 GB vs `requirements-false.txt` <3 GB).
+
+### 5.2 Kubernetes (`deploy/k8s/`)
+
+Namespace, registry secret, Redis StatefulSet, web Deployment (2 replicas + HPA 1–10), worker Deployments (CPU and GPU variants + HPA), NetworkPolicies restricting inter-pod traffic. Manifests are not validated in CI (Backlog 5.4 adjacent).
+
+### 5.3 Hardware capability matrix
+
+| Capability | GPU profile | CPU profile |
+|------------|-------------|-------------|
+| Pandoc conversion | ✅ | ✅ |
+| Marker PDF→Markdown | ✅ | ❌ |
+| Scanned PDF (OCR) | ✅ (Marker) | ❌ — no fallback (Backlog Epic 2) |
+| SLM metadata | ✅ (GPU layers) | ✅ (slower) |
+| Capture assembly (OCR path) | ✅ | ❌ degraded |
+
+---
+
+## 6. Security Architecture
+
+### 6.1 Trust boundaries
+
+```mermaid
+flowchart LR
+    NET[Internet] -->|TLS via Cloudflare Tunnel or reverse proxy| WEB[web :5000]
+    subgraph internal[Internal Docker network — no exposed ports]
+        WEB --- RED[(redis)]
+        RED --- WRK[worker]
+        WRK --- MCP[mcp-server :8080]
+    end
+    WRK -->|webhooks only, SSRF-guarded| NET
+```
+
+### 6.2 Authentication & authorization
+
+- **API keys:** `dk_`-prefixed, created/revoked via `/api/v1/auth/keys` under `ADMIN_API_SECRET` bearer auth; stored hashed (`shared/key_manager.py`); presented as `X-API-Key`. **Gap:** no expiration or usage audit log (Backlog 4.3).
+- **Sessions:** `HTTPONLY`, `SameSite=Lax`; `SESSION_COOKIE_SECURE` opt-in (must be enabled behind HTTPS).
+- **CSRF:** Flask-WTF on browser-facing routes.
+- **MCP:** bearer-token (`MCP_SECRET`) on an internal-only endpoint.
+
+### 6.3 Encryption
+
+- **Files at rest:** AES-256-GCM with per-job DEKs wrapped by `MASTER_ENCRYPTION_KEY` (`shared/encryption.py`).
+- **Redis payloads:** job metadata values encrypted (`shared/redis_encryption.py`).
+- **Key sourcing:** Docker secrets → env vars → `.env` (`shared/secrets_manager.py`); fail-fast in production if absent; ephemeral keys auto-generated in dev.
+- **Gaps:** Redis transport TLS disabled (Backlog 4.1); no documented key-rotation procedure; crypto modules excluded from test coverage (Backlog 5.1).
+
+### 6.4 Input validation (`web/validation.py`)
+
+UUID v4 validation, filename sanitization (path-traversal defense), magic-byte content checks (PDF `%PDF`, ZIP `PK`, text-encoding probes), upload size and free-disk enforcement. **Gap:** magic check reads only the first 8 bytes — polyglot files can pass (Backlog 4.4).
+
+### 6.5 Network protections
+
+- Rate limiting: Flask-Limiter (Redis-backed), defaults 1000/day + 200/hour, per-endpoint overrides on capture routes. **Gap:** `/api/v1/convert` lacks an explicit decorator (Backlog 4.2).
+- SSRF: webhook URLs validated against IP blocklists/schemes; optional HTTPS-only enforcement.
+- CORS: capture endpoints only, restricted to extension origins.
+- CSP: set in `app.py`, but includes `unsafe-inline` for SocketIO compatibility (Backlog 4.6).
+
+### 6.6 Container hardening
+
+Non-root users in web and worker images; `cap_drop: [ALL]`; `no-new-privileges`; `tmpfs /tmp noexec,nosuid,nodev`; Redis unexposed and password-protected. **Gaps:** `python:3.11-slim` / `ubuntu:22.04` base images unpinned (Backlog 5.2); MCP container runs as root with no healthcheck (Backlog 4.5).
+
+### 6.7 OSCAL control mapping
+
+`oscal/component-definition.json` and `oscal/ssp.json` map mechanisms to NIST SP 800-53 controls (AC-2/AC-3 → API keys, AU-2 → logging, SC-8 → transport encryption, SC-28 → encryption at rest), validated by `.github/workflows/oscal-validate.yml`. Closing Epic 4 gaps should update the corresponding SSP statements (Backlog 5.5).
+
+---
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Observability
+
+- **Logging:** web tier emits structured JSON with request-ID correlation; **worker logs are unstructured plain text** (Backlog 3.5).
+- **Metrics:** Prometheus counters/histograms/gauges in `worker/metrics.py` (conversion totals/durations/failures, GPU utilization, queue depth) + `prometheus-flask-exporter` on web; Grafana dashboard and alert rules in `docs/`.
+- **Healthchecks:** `/healthz`, `/readyz`, `/api/health` on web. **Known bug:** the worker container's Docker healthcheck targets the MCP server's endpoint, not the worker itself (Backlog 3.2).
+
+### 7.2 Configuration
+
+Single Pydantic Settings class (`config.py`); precedence Docker secrets → environment → `.env` → defaults; `SecretStr` for all credentials. Full reference: [CONFIGURATION.md](CONFIGURATION.md).
+
+### 7.3 Model lifecycle
+
+- Marker models: lazy `create_model_dict()` on first conversion (~30 s), cached per worker process (recycled every 50 tasks via `max_tasks_per_child`).
+- SLM (TinyLlama GGUF): eagerly loaded at worker start (`warmup.py`), GPU layers when available.
+- GPU memory: explicit `gc.collect()` + `torch.cuda.empty_cache()` after Marker tasks; fragmentation can still accumulate (Backlog 6.6).
+
+---
+
+## 8. Architecture Decision Records (retroactive)
+
+### ADR-001: Eventlet + Flask-SocketIO for real-time updates
+**Decision:** Use Flask with eventlet monkey-patching and Flask-SocketIO rather than an ASGI stack.
+**Rationale:** WebSocket progress with minimal divergence from a conventional Flask app; Redis message queue lets multiple web replicas broadcast.
+**Consequences:** Eventlet is in maintenance mode upstream; CSP needs `unsafe-inline` accommodations; future migration to gevent/threading or ASGI may be required (PRD §10).
+
+### ADR-002: Celery `pool=solo`, concurrency 1
+**Decision:** One task at a time per worker process.
+**Rationale:** Marker and the SLM contend for a single GPU; serializing avoids VRAM exhaustion and CUDA context conflicts. `max_tasks_per_child=50` bounds memory creep.
+**Consequences:** Head-of-line blocking — a 20-minute Marker job stalls Pandoc and maintenance tasks. Mitigation: queue separation with a light-lane worker (Backlog 6.3).
+
+### ADR-003: Redis as the only datastore
+**Decision:** Job metadata, capture sessions, API keys, and rate limits all live in Redis; no RDBMS.
+**Rationale:** Jobs are transient by design (retention minutes-to-hours); Redis already serves as Celery broker; one fewer stateful service to operate.
+**Consequences:** No relational querying or long-term history; durability depends on AOF; `noeviction` at 256 MB means load spikes surface as write errors rather than silent data loss.
+
+### ADR-004: Envelope encryption at rest
+**Decision:** AES-256-GCM with per-job data-encryption keys wrapped by a master key, applied to files and Redis metadata values.
+**Rationale:** Confidentiality on shared volumes and in Redis dumps; per-job DEKs limit blast radius; GCM provides integrity.
+**Consequences:** Key management is the critical path (rotation undocumented); crypto code must be test-covered (currently excluded — Backlog 5.1); CPU overhead on every file touch.
+
+### ADR-005: Hybrid engine with words/page heuristic
+**Decision:** `pdf_hybrid` tries Pandoc first and falls back to Marker when output is below 50 words/page.
+**Rationale:** Pandoc is orders of magnitude cheaper; only pay GPU cost when fast conversion visibly fails.
+**Consequences:** The heuristic misses degradation that preserves word count (mangled tables, shuffled columns, garbage characters) and wastes Marker runs on legitimately sparse documents. Superseded by quality scoring (Backlog 1.1/1.2).
+
+---
+
+## 9. Known Limitations and Planned Evolution
+
+| Limitation | Where | Planned evolution |
+|------------|-------|-------------------|
+| No quality signal on conversions | `worker/tasks/conversion.py`, API responses | [Backlog Epic 1](BACKLOG.md#epic-1) — scoring, smarter routing, quality in API |
+| No OCR on CPU deployments | worker CPU image | [Backlog Epic 2](BACKLOG.md#epic-2) — Tesseract fallback + routing |
+| Silent partial failures, temp-file leaks, healthcheck bug | worker tasks, compose | [Backlog Epic 3](BACKLOG.md#epic-3) |
+| Redis TLS off, key lifecycle, shallow validation, MCP root | redis, key_manager, validation, mcp_server | [Backlog Epic 4](BACKLOG.md#epic-4) |
+| Untested crypto, unpinned images, no lint/SAST/scan/SBOM | `.coveragerc`, Dockerfiles, CI | [Backlog Epic 5](BACKLOG.md#epic-5) |
+| Cold-start latency, head-of-line blocking, memory-bound I/O | warmup, queues, storage | [Backlog Epic 6](BACKLOG.md#epic-6) |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,546 @@
+# DocuFlux — Improvement Epic Backlog
+
+**Status:** Proposed · **Last updated:** 2026-06-11
+**Related docs:** [PRD.md](PRD.md) · [ARCHITECTURE.md](ARCHITECTURE.md)
+
+Six epics covering the four improvement themes: **capability** (Epic 2), **PDF→Markdown conversion quality** (Epic 1), **hardening** (Epics 4–5), and **code optimization** (Epics 3, 6). Stories use BDD framing per the project's BDD conventions; each names the files it touches.
+
+**Cross-epic priority order:** E1 ≈ E4 > E2 ≈ E3 > E5 > E6 — but see [§ Execution Order](#execution-order) for the dependency-aware sequencing, and note Story 5.1 is a P0 prerequisite for parts of Epic 4.
+
+---
+
+<a id="epic-1"></a>
+## Epic 1 — Trustworthy PDF→Markdown Output `@conversion-quality` — **P0**
+
+> **Vision:** Reduce unusable or silently-degraded conversion outputs to under 2% of jobs within two release cycles by scoring every conversion and replacing the crude fallback heuristic. (Baseline: unmeasurable today — Story 1.1 creates the measurement.)
+
+```gherkin
+Feature: Conversion output quality
+  In order to trust converted Markdown without manual inspection
+  As an API integrator feeding documents into downstream pipelines
+  I want every conversion scored, validated, and post-processed for fidelity
+```
+
+| # | Story | Priority | Depends on |
+|---|-------|----------|------------|
+| 1.1 | Quality scoring of converted Markdown | **P0** | — |
+| 1.2 | Replace 50-words/page hybrid heuristic with the quality score | **P0** | 1.1 |
+| 1.3 | Surface quality report in job metadata and API responses | P1 | 1.1 |
+| 1.4 | Table post-processing and normalization | P1 | 1.1 |
+| 1.5 | Inline extracted images into Markdown output | P1 | — |
+| 1.6 | Chunked SLM metadata extraction for long documents | P2 | — |
+
+### Story 1.1 — Quality scoring of converted Markdown
+
+```gherkin
+In order to detect degraded conversions before users do
+As a self-hoster operating DocuFlux for my team
+I want each conversion to produce a structured quality score
+```
+
+**Acceptance criteria**
+- New `shared/quality.py` module scores Markdown output on: word density per page, heading-structure presence, table well-formedness, garbage-character ratio, empty-page ratio.
+- Score (grade + reason codes) persisted via `shared/job_metadata.py` for every conversion task.
+- Deterministic; unit-tested against fixtures in `tests/samples/` (text PDF, scanned PDF, table-heavy PDF).
+
+```gherkin
+Scenario: The one where a scanned PDF through Pandoc yields 3 words per page
+  Given a scanned PDF converted via the Pandoc engine
+  When quality scoring runs on the output
+  Then the job carries quality grade "poor" with reason code "low_word_density"
+```
+
+**Files:** new `shared/quality.py`, `worker/tasks/conversion.py`, `shared/job_metadata.py`, `tests/unit/`.
+**Note:** highest-leverage story in the backlog — feeds 1.2, 1.3, 2.2, and 3.1.
+
+### Story 1.2 — Smarter hybrid fallback routing
+
+```gherkin
+In order to get the best engine for each document without paying GPU cost unnecessarily
+As a self-hoster running the hybrid engine
+I want fallback decisions driven by the quality score instead of a fixed words-per-page count
+```
+
+**Acceptance criteria**
+- The fixed 50-words/page check (`_assess_pandoc_quality` in `worker/tasks/conversion.py`) is replaced by the Story 1.1 scorer.
+- Fallback threshold configurable via `config.py`; every fallback decision logged with reason codes.
+- Scenario outline over sample documents asserts the chosen engine:
+
+```gherkin
+Scenario Outline: Engine routing by document type
+  Given a <document> uploaded with engine pdf_hybrid
+  When the hybrid conversion completes
+  Then the final engine used should be <engine>
+
+  Examples:
+    | document          | engine |
+    | text-based PDF    | pandoc |
+    | scanned PDF       | marker |
+    | table-heavy PDF   | marker |
+```
+
+**Files:** `worker/tasks/conversion.py`, `config.py`, `tests/unit/test_worker.py`.
+
+### Story 1.3 — Quality report in API responses
+
+```gherkin
+In order to react to degraded conversions programmatically
+As an API integrator
+I want the quality grade and reason codes in status, download metadata, and webhook payloads
+```
+
+**Acceptance criteria**
+- `GET /api/v1/status/{job_id}` and webhook payloads include a `quality` object (grade, reasons, per-dimension scores); `docs/openapi.yaml` updated.
+- Degraded jobs complete as **completed-with-warnings**, never silently as plain success.
+- Extension and MCP consumers receive the same structure.
+
+**Files:** `web/routes/conversion.py`, `web/routes/webhooks.py`, `docs/openapi.yaml`, `docs/API.md`.
+
+### Story 1.4 — Table post-processing and normalization
+
+```gherkin
+In order to receive usable Markdown tables from layout-heavy PDFs
+As an agent consumer indexing structured content
+I want converted tables normalized and repaired after engine output
+```
+
+**Acceptance criteria**
+- Post-process step normalizes pipe-table alignment, header rows, and merged-cell artifacts from Marker/Pandoc output.
+- Unrepairable tables flagged via quality reason codes (1.1) rather than silently passed through.
+- Round-trip tests on table-heavy samples in `tests/samples/`.
+
+**Files:** `worker/tasks/conversion.py` (or new `shared/table_postprocess.py`), `tests/unit/`.
+
+### Story 1.5 — Inline extracted images into Markdown output
+
+```gherkin
+In order to get a self-contained document
+As an extension user downloading converted output
+I want extracted images referenced with working relative links and included in the archive
+```
+
+**Acceptance criteria**
+- Marker-extracted images written alongside output; Markdown references use relative `images/...` paths that resolve inside the downloaded zip.
+- Option to omit images for text-only consumers.
+
+**Files:** `worker/tasks/conversion.py`, `web/routes/conversion.py` (download/zip path), `shared/storage.py`.
+
+### Story 1.6 — Chunked SLM metadata extraction for long documents
+
+```gherkin
+In order to get accurate titles and summaries for long documents
+As an agent consumer feeding RAG pipelines
+I want metadata extraction that samples the whole document instead of the first 2,000 tokens
+```
+
+**Acceptance criteria**
+- Replace the truncation at `MAX_SLM_CONTEXT` with head+tail sampling or map-reduce chunking in `worker/tasks/metadata.py`.
+- Measurably better metadata on a >50-page fixture set; bounded total latency.
+
+**Files:** `worker/tasks/metadata.py`, `config.py`, `tests/unit/`.
+
+---
+
+<a id="epic-2"></a>
+## Epic 2 — Scanned Documents on Any Hardware `@capability @ocr` — **P0**
+
+> **Vision:** Raise scanned-PDF support on CPU-only deployments from ~0% to >90% of documents within one release cycle by adding a Tesseract OCR fallback path.
+
+```gherkin
+Feature: OCR fallback for scanned documents
+  In order to convert scanned documents without buying a GPU
+  As a self-hoster running the CPU-only compose profile
+  I want an OCR pipeline that activates whenever Marker is unavailable
+```
+
+| # | Story | Priority | Depends on |
+|---|-------|----------|------------|
+| 2.1 | Tesseract OCR engine integration | **P0** | — |
+| 2.2 | Scanned-PDF detection and routing | **P0** | 2.1, 1.1 |
+| 2.3 | Engine capability advertisement | P1 | 2.1 |
+| 2.4 | SLM cleanup pass for OCR artifacts | P2 | 2.1 |
+
+### Story 2.1 — Tesseract OCR engine integration
+
+**Acceptance criteria**
+- `tesseract-ocr` added to the CPU worker image (`worker/Dockerfile` CPU branch, `requirements-false.txt` path) with configurable language packs (CJK relevant per `docs/IMPLEMENTATION_SUMMARY_CJK.md`).
+- New OCR conversion branch/task in `worker/tasks/conversion.py` producing Markdown from image-only PDFs.
+
+```gherkin
+Scenario: The one where a scanned PDF converts on the CPU profile
+  Given DocuFlux is running via docker-compose.cpu.yml
+  When a scanned PDF is submitted for conversion to Markdown
+  Then the job completes with readable Markdown output
+```
+
+**Files:** `worker/Dockerfile`, `worker/requirements-false.txt`, `worker/tasks/conversion.py`, `shared/formats.py`.
+
+### Story 2.2 — Scanned-PDF detection and routing
+
+**Acceptance criteria**
+- Image-only pages (zero extractable text) detected up front; such PDFs route to OCR instead of returning empty Pandoc output.
+- OCR output also validated by the Epic 1 quality scorer.
+
+**Files:** `worker/tasks/conversion.py`, `shared/quality.py`.
+
+### Story 2.3 — Engine capability advertisement
+
+**Acceptance criteria**
+- API reports available engines (marker / ocr / slm) per deployment — via `/api/v1/formats` or `web/routes/health.py` — so the extension and MCP server can adapt.
+- `docs/API.md` and `docs/openapi.yaml` updated.
+
+```gherkin
+Scenario: The one where an agent asks what this deployment can do
+  Given a CPU-only deployment with Tesseract installed
+  When the agent queries engine capabilities
+  Then the response lists ocr as available and marker as unavailable
+```
+
+**Files:** `web/routes/health.py` or `web/routes/conversion.py`, `mcp_server/server.js`, `docs/openapi.yaml`.
+
+### Story 2.4 — SLM cleanup pass for OCR artifacts
+
+**Acceptance criteria**
+- Reuse the existing SLM refinement pattern (`worker/tasks/metadata.py` / `_slm_refine_markdown`) on Tesseract output; gated by quality score so CPU time isn't wasted on clean output.
+
+**Files:** `worker/tasks/conversion.py`, `worker/tasks/metadata.py`.
+
+---
+
+<a id="epic-3"></a>
+## Epic 3 — Fail Loud, Recover Clean `@reliability` — **P0/P1**
+
+> **Vision:** Drive silent-failure incidents and orphaned-temp-file growth to zero within one release cycle by validating every engine's output and making lifecycle cleanup timeout-safe.
+
+```gherkin
+Feature: Honest failure reporting
+  In order to never ship a half-converted document as a success
+  As an API integrator relying on job status
+  I want every partial or failed conversion detected, reported, and cleaned up
+```
+
+| # | Story | Priority | Depends on |
+|---|-------|----------|------------|
+| 3.1 | Detect Pandoc partial/empty output | **P0** | synergizes with 1.1 |
+| 3.2 | Fix worker healthcheck target | **P0** · quick win | — |
+| 3.3 | Timeout-safe temp file cleanup + orphan sweep | P1 | — |
+| 3.4 | SLM JSON parse failures surfaced, with one repair retry | P1 | — |
+| 3.5 | Structured JSON logging in workers | P1 | — |
+
+### Story 3.1 — Detect Pandoc partial/empty output
+
+**Acceptance criteria**
+- `worker/tasks/conversion.py` checks Pandoc exit semantics plus output size/quality; empty or near-empty output marks the job FAILED with a reason, never COMPLETED.
+
+```gherkin
+Scenario: The one where Pandoc writes a 0-byte file but exits 0
+  Given a malformed document submitted for Pandoc conversion
+  When Pandoc exits successfully but produces an empty output file
+  Then the job status is "failed" with reason "empty_output"
+```
+
+**Files:** `worker/tasks/conversion.py`, `tests/unit/test_worker.py`.
+
+### Story 3.2 — Fix worker healthcheck target
+
+**Acceptance criteria**
+- The worker container healthcheck currently probes the MCP server's endpoint; replace with a real worker check (`celery inspect ping` or a heartbeat file).
+- Orchestrators (compose/k8s) restart the worker when Celery is actually dead.
+
+**Files:** `docker-compose.yml`, `worker/Dockerfile`, `deploy/k8s/worker.yaml`.
+
+### Story 3.3 — Timeout-safe temp file cleanup + orphan sweep
+
+**Acceptance criteria**
+- Temp directories in `worker/tasks/conversion.py` and `worker/tasks/capture.py` wrapped in context managers / `try-finally`.
+- Beat-scheduled orphan sweep added to `worker/tasks/maintenance.py`.
+
+```gherkin
+Scenario: The one where the worker is killed mid-conversion
+  Given a conversion task in progress with temp files on disk
+  When the task is killed by a hard timeout
+  Then no temp files remain after the next maintenance sweep
+```
+
+**Files:** `worker/tasks/conversion.py`, `worker/tasks/capture.py`, `worker/tasks/maintenance.py`.
+
+### Story 3.4 — SLM JSON parse failures surfaced
+
+**Acceptance criteria**
+- A parse failure in `worker/tasks/metadata.py` logs the failure, sets a `metadata_degraded` flag in job metadata, and performs one constrained re-prompt — never a silent identical fallback.
+
+**Files:** `worker/tasks/metadata.py`, `shared/job_metadata.py`.
+
+### Story 3.5 — Structured JSON logging in workers
+
+**Acceptance criteria**
+- Workers emit the same JSON log format as the web tier (new `shared/logging.py` consumed by both), with `job_id`/`task_id` correlation fields.
+- Prerequisite for audit logging (4.3) and performance baselining (6.1).
+
+**Files:** new `shared/logging.py`, `worker/tasks/__init__.py`, `web/app.py` (adopt shared config).
+
+---
+
+<a id="epic-4"></a>
+## Epic 4 — Close the Hardening Gaps `@security` — **P0**
+
+> **Vision:** Close all known-open security gaps (Redis TLS, key lifecycle, validation depth, MCP container posture) within one release cycle, with each closure mapped to an OSCAL control in `oscal/`.
+
+```gherkin
+Feature: Runtime security hardening
+  In order to deploy DocuFlux in environments handling sensitive documents
+  As a self-hoster with compliance obligations
+  I want the documented "temporary" security exceptions actually closed
+```
+
+| # | Story | Priority | Depends on |
+|---|-------|----------|------------|
+| 4.1 | Re-enable Redis TLS | **P0** | — |
+| 4.2 | Explicit rate limit on /api/v1/convert | **P0** · quick win | — |
+| 4.3 | API key expiration and audit logging | P1 | 3.5; **blocked by 5.1** |
+| 4.4 | Deep upload validation (beyond 8 magic bytes) | P1 | **blocked by 5.1** |
+| 4.5 | MCP server: non-root user + healthcheck | P1 | — |
+| 4.6 | Remove CSP unsafe-inline | P2 | — |
+
+### Story 4.1 — Re-enable Redis TLS
+
+**Acceptance criteria**
+- Certificate generation wired end-to-end (`scripts/generate-redis-certs.sh`, `deploy/certs/`); `shared/redis_client.py` TLS options enabled; `docker-compose.tls.yml` no longer inert.
+- All four Redis consumers (web, worker, beat, rate limiter) connect over TLS; plaintext connections refused.
+- Documented in `docs/CERTIFICATE_MANAGEMENT.md`; OSCAL SC-8 statement updated.
+
+**Files:** `docker-compose.tls.yml`, `shared/redis_client.py`, `scripts/generate-redis-certs.sh`, `docs/CERTIFICATE_MANAGEMENT.md`, `oscal/ssp.json`.
+
+### Story 4.2 — Explicit rate limit on /api/v1/convert
+
+**Acceptance criteria**
+- Flask-Limiter decorator on the convert route in `web/routes/conversion.py` (limiter infrastructure already present); limit configurable; test asserting 429 behavior.
+
+**Files:** `web/routes/conversion.py`, `tests/unit/test_api_v1.py`.
+
+### Story 4.3 — API key expiration and audit logging
+
+```gherkin
+In order to limit the blast radius of a leaked key
+As a self-hoster with compliance obligations
+I want keys that expire and an audit trail of their use
+```
+
+**Acceptance criteria**
+- `shared/key_manager.py` gains `expires_at` and last-used tracking; `web/routes/auth.py` enforces expiry.
+- Auth events (key ID — never the key) emitted to structured logs.
+
+```gherkin
+Scenario: The one where an expired key is used
+  Given an API key past its expires_at timestamp
+  When a conversion request presents that key
+  Then the response is 401 with a distinct "key_expired" error code
+  And an audit event is logged with the key ID
+```
+
+**Files:** `shared/key_manager.py`, `web/routes/auth.py`, `web/app.py`. **Prerequisite:** 5.1 (tests must exist before modifying key_manager) and 3.5 (structured logs).
+
+### Story 4.4 — Deep upload validation
+
+**Acceptance criteria**
+- Validation extended beyond the first 8 bytes: declared extension vs detected content type vs parsed structure must agree; mismatches rejected.
+
+```gherkin
+Scenario: The one where a ZIP-PDF polyglot is uploaded as .pdf
+  Given a file that is simultaneously a valid ZIP and a valid PDF
+  When it is uploaded with a .pdf extension
+  Then the upload is rejected with a content-mismatch error
+```
+
+**Files:** `web/validation.py`, `tests/unit/test_validation.py`. **Prerequisite:** 5.1 (validation module must be under coverage first).
+
+### Story 4.5 — MCP server: non-root user + healthcheck
+
+**Acceptance criteria**
+- `mcp_server/Dockerfile` adds a `USER` directive (mind Playwright sandbox/user permissions) and a `HEALTHCHECK`; compose/k8s pick it up.
+
+**Files:** `mcp_server/Dockerfile`, `docker-compose.yml`.
+
+### Story 4.6 — Remove CSP unsafe-inline
+
+**Acceptance criteria**
+- Inline scripts/styles in `web/templates/` moved to static files or covered by nonces; SocketIO client verified working; CSP header in `web/app.py` drops `unsafe-inline`.
+
+**Files:** `web/app.py`, `web/templates/`.
+
+---
+
+<a id="epic-5"></a>
+## Epic 5 — Trustworthy Build and Test Pipeline `@supply-chain @ci` — **P1** (5.1 is P0)
+
+> **Vision:** Make CI block every release on lint, SAST, container scan, and real coverage of security-critical modules within one release cycle. (Today CI runs pytest + vitest only, and the crypto modules are excluded from coverage.)
+
+```gherkin
+Feature: Verified supply chain
+  In order to trust that each release is at least as secure as the last
+  As a maintainer publishing images self-hosters will run
+  I want automated security and quality gates on every change
+```
+
+| # | Story | Priority | Depends on |
+|---|-------|----------|------------|
+| 5.1 | Bring crypto/validation modules under test coverage | **P0** | — · **blocks 4.3, 4.4** |
+| 5.2 | Pin base images by digest + update automation | P1 · quick win | — |
+| 5.3 | Lint and type-check gates (ruff, mypy, eslint) | P1 | — |
+| 5.4 | SAST, container scanning, SBOM in CI | P1 | 5.2 helps |
+| 5.5 | OSCAL evidence wiring for new gates | P2 | 5.3, 5.4 |
+
+### Story 5.1 — Test the crypto
+
+**Acceptance criteria**
+- Coverage exclusions removed from `.coveragerc` for `shared/encryption.py`, `shared/key_manager.py`, `shared/secrets_manager.py`, `web/validation.py`, `worker/metrics.py`, `worker/warmup.py`.
+- Unit tests added: AES-256-GCM known-answer vectors, tamper detection (auth-tag failure), DEK wrap/unwrap, key creation/revocation/hash verification, secrets precedence (Docker secret → env → .env).
+- Overall coverage threshold raised (70% → 80%+ as a first step).
+
+**Files:** `.coveragerc`, `tests/unit/` (new test modules), `pytest.ini`.
+**Rationale for P0:** Epic 4 stories 4.3/4.4 modify these exact modules — never change untested security code.
+
+### Story 5.2 — Pin base images by digest
+
+**Acceptance criteria**
+- `python:3.11-slim@sha256:…`, `ubuntu:22.04@sha256:…` (and the CUDA/Playwright images) pinned in `web/`, `worker/`, `mcp_server/` Dockerfiles; Dependabot/Renovate configured to propose digest bumps.
+
+**Files:** `web/Dockerfile`, `worker/Dockerfile`, `mcp_server/Dockerfile`, `.github/dependabot.yml`.
+
+### Story 5.3 — Lint and type-check gates
+
+**Acceptance criteria**
+- ruff + mypy configs added (none exist today); eslint for `extension-src/` and `mcp_server/`; staged adoption in `.github/workflows/ci.yml` (warn → enforce).
+
+**Files:** new `pyproject.toml` (ruff/mypy sections) or `ruff.toml`, `extension-src/.eslintrc`, `.github/workflows/ci.yml`.
+
+### Story 5.4 — SAST, container scanning, SBOM
+
+**Acceptance criteria**
+- CI jobs added: bandit or semgrep (SAST), trivy or grype (image scan, fail on high severity), syft (SBOM artifact attached to releases).
+
+**Files:** `.github/workflows/ci.yml`.
+
+### Story 5.5 — OSCAL evidence wiring
+
+**Acceptance criteria**
+- New CI gates mapped into `oscal/` SSP statements (SA-11, RA-5, SI-2 class controls); `oscal-validate.yml` continues to pass.
+
+**Files:** `oscal/ssp.json`, `oscal/component-definition.json`, `.github/workflows/oscal-validate.yml`.
+
+---
+
+<a id="epic-6"></a>
+## Epic 6 — Lean, Fast, Maintainable Core `@performance @code-quality` — **P1/P2**
+
+> **Vision:** Cut p95 first-conversion latency by the ~30 s model-load penalty and cap web/worker memory at a constant bound regardless of file size, within two release cycles. (Baselines unknown — Story 6.1 establishes them first.)
+
+```gherkin
+Feature: Efficient conversion service
+  In order to convert large documents on modest hardware without stalls
+  As a self-hoster on a single small server
+  I want streaming I/O, a warm model, and a worker that is never head-of-line blocked
+```
+
+| # | Story | Priority | Depends on |
+|---|-------|----------|------------|
+| 6.1 | Baseline performance measurement | P1 | 3.5 |
+| 6.2 | Eager Marker model warmup | P1 | — |
+| 6.3 | Queue separation: heavy vs light lanes | P1 | 3.2 |
+| 6.4 | Refactor long routes + shared metadata builder + type hints | P1 | — |
+| 6.5 | Streaming storage I/O and zip generation | P1 | 6.4 |
+| 6.6 | Status-poll efficiency + GPU memory release | P2 | 6.1 |
+
+### Story 6.1 — Baseline performance measurement
+
+**Acceptance criteria**
+- `worker/metrics.py` + `tests/load/locustfile.py` extended to record per-engine latency, RSS, and GPU memory; results published to the Grafana dashboard.
+- Without this, the epic's vision metric is unmeasurable.
+
+**Files:** `worker/metrics.py`, `tests/load/locustfile.py`, `docs/grafana-dashboard.json`.
+
+### Story 6.2 — Eager Marker model warmup
+
+**Acceptance criteria**
+- `worker/warmup.py` preloads Marker models (and optionally the SLM) at worker start behind a config flag; the fixed healthcheck (3.2) reports warm/cold state.
+
+```gherkin
+Scenario: The one where the first PDF is no slower than the tenth
+  Given a freshly started GPU worker with warmup enabled
+  When the first Marker conversion is submitted
+  Then it does not pay a model-loading penalty
+```
+
+**Files:** `worker/warmup.py`, `config.py`, `worker/entrypoint.sh`.
+
+### Story 6.3 — Queue separation: heavy vs light lanes
+
+**Acceptance criteria**
+- A second Celery worker (or `-Q` split) so a 10-minute Marker job no longer blocks Pandoc, metadata, and maintenance tasks; GPU exclusivity preserved (heavy lane stays concurrency 1).
+- Compose files gain a light-worker service; routing updated in `worker/tasks/__init__.py`.
+
+**Files:** `worker/tasks/__init__.py`, `docker-compose*.yml`, `deploy/k8s/worker.yaml`.
+
+### Story 6.4 — Refactor long routes + shared metadata builder + type hints
+
+**Acceptance criteria**
+- `api_v1_convert` (~141 lines) and `convert` (~89 lines) in `web/routes/conversion.py` split into validate/enqueue/respond helpers.
+- Duplicated job-metadata dict construction (conversion + capture routes) consolidated into `shared/job_metadata.py`.
+- Type hints added to route handlers and worker tasks (feeds the 5.3 mypy gate).
+
+**Files:** `web/routes/conversion.py`, `web/routes/capture.py`, `shared/job_metadata.py`, `worker/tasks/*.py`.
+
+### Story 6.5 — Streaming storage I/O and zip generation
+
+**Acceptance criteria**
+- Chunked download reads in `shared/storage.py` (local + S3); zip downloads streamed (e.g., spooled temp file or zipstream) instead of built in `BytesIO`.
+
+```gherkin
+Scenario: The one where a 500 MB output doesn't balloon web memory
+  Given a completed job with a 500 MB multi-file output
+  When the client downloads the zipped result
+  Then web-process memory stays within a constant bound
+```
+
+**Files:** `shared/storage.py`, `web/routes/conversion.py`.
+
+### Story 6.6 — Status-poll efficiency + GPU memory release
+
+**Acceptance criteria**
+- ETag/Cache-Control on status endpoints; repeated per-poll `hgetall` collapsed to a single round trip.
+- Explicit GPU memory management verified after Marker tasks in `worker/tasks/conversion.py` and `capture.py` (no monotonic VRAM growth across 50-task child lifetime).
+
+**Files:** `web/routes/conversion.py`, `worker/tasks/conversion.py`, `worker/tasks/capture.py`.
+
+---
+
+## Cross-Epic Dependencies
+
+```mermaid
+flowchart LR
+    S51[5.1 crypto tests] --> S43[4.3 key expiry/audit]
+    S51 --> S44[4.4 deep validation]
+    S11[1.1 quality scorer] --> S12[1.2 hybrid routing]
+    S11 --> S13[1.3 quality in API]
+    S11 --> S22[2.2 scanned-PDF routing]
+    S11 -.synergy.-> S31[3.1 empty-output detection]
+    S35[3.5 structured worker logs] --> S43
+    S35 --> S61[6.1 perf baselines]
+    S32[3.2 healthcheck fix] --> S63[6.3 queue split]
+    S21[2.1 Tesseract] --> S22
+    S64[6.4 refactor] --> S65[6.5 streaming I/O]
+```
+
+- **5.1 blocks 4.3 and 4.4** — never modify untested security modules.
+- **1.1 is the highest-leverage story** — four other stories build on it.
+- **Quick wins** (small, independent, high value): **4.2** (rate-limit decorator), **3.2** (healthcheck fix), **5.2** (image pinning).
+
+<a id="execution-order"></a>
+## Execution Order
+
+| Wave | Stories |
+|------|---------|
+| **0 — Docs** | PRD.md, ARCHITECTURE.md (done — this backlog accompanies them) |
+| **1 — P0** | 4.2, 3.2 (quick wins) → 5.1 → 1.1 → 4.1, 3.1, 2.1 → 2.2, 1.2 |
+| **2 — P1** | 1.3, 1.4, 1.5, 2.3, 3.3, 3.4, 3.5, 4.3, 4.4, 4.5, 5.2, 5.3, 5.4, 6.1, 6.2, 6.3, 6.4, 6.5 |
+| **3 — P2** | 1.6, 2.4, 4.6, 5.5, 6.6 |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,269 @@
+# DocuFlux — Product Requirements Document
+
+**Status:** Living document · **Last updated:** 2026-06-11
+**Related docs:** [ARCHITECTURE.md](ARCHITECTURE.md) · [BACKLOG.md](BACKLOG.md) · [API.md](API.md) · [FORMATS.md](FORMATS.md) · [CONFIGURATION.md](CONFIGURATION.md) · [AI_INTEGRATION.md](AI_INTEGRATION.md)
+
+---
+
+## 1. Product Overview
+
+### 1.1 Pitch
+
+DocuFlux is a **self-hostable, privacy-first document conversion service**. It combines three conversion engines — Pandoc (universal, 20+ formats), Marker AI (deep-learning PDF→Markdown with layout awareness), and a local small language model (SLM) for metadata extraction — behind a REST API, a Material Design web UI, browser extensions for authenticated web capture, and a Model Context Protocol (MCP) server for AI-agent integration.
+
+### 1.2 Problem Statement
+
+- **Cloud converters leak documents.** Sending contracts, medical records, or internal documentation to a SaaS converter is unacceptable for many individuals and organizations.
+- **Local tools lack quality AI conversion.** Pandoc alone produces poor results on scanned or layout-heavy PDFs; high-fidelity PDF→Markdown historically required cloud APIs.
+- **Automation surfaces are missing.** Most local converters are CLIs or desktop apps with no job queue, no webhooks, no API keys, and no agent integration.
+
+DocuFlux solves all three: documents never leave the deployment, AI conversion runs on local hardware (GPU-accelerated when available), and every capability is exposed through a versioned API.
+
+### 1.3 Product Principles
+
+1. **Data never leaves the deployment.** No external API calls for conversion or metadata extraction. Models run locally (Marker, TinyLlama via llama-cpp-python).
+2. **Encrypted by default.** Files at rest use AES-256-GCM (`shared/encryption.py`); job metadata in Redis is encrypted (`shared/redis_encryption.py`).
+3. **Degrades gracefully across hardware.** Full capability on a single NVIDIA GPU; CPU-only deployments retain Pandoc-based conversion (see §9 for the scanned-PDF gap).
+4. **Transient by design.** Outputs auto-expire (10 min after download / 1 hour undownloaded / 5 min for failures). DocuFlux is a converter, not a document store.
+5. **API-first.** Every UI action maps to a documented REST endpoint ([openapi.yaml](openapi.yaml)).
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+| Goal | Mechanism |
+|------|-----------|
+| High-fidelity document conversion, especially PDF→Markdown | Marker AI + hybrid Pandoc/Marker routing |
+| API-first automation | REST API v1, `dk_` API keys, webhooks, WebSocket progress |
+| Agent integration | MCP server (Playwright-backed vision capture), machine-readable API docs |
+| Authenticated web content capture | Chrome/Firefox extensions with batch session assembly |
+| Compliance-ready security posture | NIST SP 800-53 mappings in `oscal/` (component definition + SSP) |
+| Runs on commodity hardware | CPU and GPU Docker Compose profiles; Kubernetes manifests with HPA |
+
+### 2.2 Non-Goals
+
+- **Multi-tenant SaaS.** DocuFlux is single-deployment, single-trust-domain software. API keys gate access; there is no tenant isolation model.
+- **Document storage/management.** Retention is deliberately transient. No folders, search, or versioning.
+- **Real-time collaborative editing.** Output is downloaded, not edited in place.
+- **Format authoring.** DocuFlux converts; it does not provide editors for the formats it supports.
+
+---
+
+## 3. Personas
+
+### 3.1 Self-Hoster "Sam"
+
+Runs DocuFlux on a homelab or small-org server via `docker-compose.gpu.yml` or `docker-compose.cpu.yml`.
+
+- **Cares about:** setup friction, hardware requirements, upgrade safety, TLS, resource limits.
+- **Pains (current):** Marker requires a GPU — scanned PDFs are effectively unsupported on CPU-only hardware; Redis TLS is disabled pending certificate generation; first Marker conversion is slow (~30 s lazy model load).
+
+### 3.2 API Integrator "Ines"
+
+Calls `POST /api/v1/convert` from backend pipelines using `dk_`-prefixed API keys.
+
+- **Cares about:** predictable JSON contracts, webhook reliability, rate limits, error semantics, job latency.
+- **Pains (current):** no quality signal in responses — a degraded conversion looks identical to a good one; partial Pandoc output can complete "successfully"; API keys have no expiration or audit trail.
+
+### 3.3 Extension User "Eva"
+
+Uses the Chrome/Firefox extension (`extension-src/`) to capture authenticated web content (e.g., Percipio/Skillsoft readers) page-by-page into a single Markdown document.
+
+- **Cares about:** one-click capture, batch reliability across hundreds of pages, fidelity of the assembled document.
+- **Pains (current):** capture quality depends on Marker OCR of screenshots; no per-page quality feedback; sessions cap at 500 pages.
+
+### 3.4 Agent/MCP Consumer "Astra"
+
+An LLM agent using the MCP server (`mcp_server/server.js`, Playwright-backed) and the REST API for autonomous document acquisition and conversion, often feeding downstream RAG pipelines.
+
+- **Cares about:** structured outputs, reliable tool contracts, metadata quality (title/summary/tags) for indexing.
+- **Pains (current):** SLM metadata is truncated at 2,000 tokens — long documents get poor titles/summaries; no machine-readable engine-capability discovery (the agent cannot ask "is OCR available here?").
+
+---
+
+## 4. User Journeys
+
+### 4.1 Sam: Install → First Conversion
+
+1. Clone repo, run `./scripts/build.sh auto` (GPU auto-detection).
+2. `docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d`.
+3. Open `http://localhost:5000`, upload a PDF, select "PDF (High Accuracy)".
+4. Watch real-time progress via WebSocket; download Markdown + extracted images as a zip.
+5. (Optional) Configure Cloudflare Tunnel or Redis TLS per [CLOUDFLARE_TUNNEL_SETUP.md](CLOUDFLARE_TUNNEL_SETUP.md) / [CERTIFICATE_MANAGEMENT.md](CERTIFICATE_MANAGEMENT.md).
+
+### 4.2 Ines: Key → Convert → Webhook → Download
+
+1. Admin issues a key: `POST /api/v1/auth/keys` (Bearer `ADMIN_API_SECRET`).
+2. Pipeline uploads: `POST /api/v1/convert` (multipart, `engine=pdf_hybrid`), receives `job_id`.
+3. Registers callback: `POST /api/v1/webhooks` with `job_id` + HTTPS URL (SSRF-validated).
+4. On completion, webhook fires with status + download URL; pipeline fetches `GET /api/v1/download/{job_id}`.
+5. Output auto-expires per retention policy.
+
+### 4.3 Eva: Extension Capture
+
+1. Installs extension; configures DocuFlux server URL and API key in the popup.
+2. Opens a paywalled/authenticated reader; clicks "Capture Pages".
+3. Extension creates a capture session (`POST /api/v1/capture/sessions`), then streams pages (HTML + screenshot) in batches of 50.
+4. On "Finish", the worker assembles batches: screenshots → PDF → Marker (force-OCR) → merged Markdown with YAML front matter.
+5. Eva downloads the assembled document.
+
+### 4.4 Astra: MCP Tool Call → Conversion → Metadata
+
+1. Agent invokes an MCP tool; the MCP server drives Playwright to render and capture target content.
+2. Captured content enters the same capture/conversion pipeline.
+3. Worker runs Marker, then queues `tasks.extract_slm_metadata` — TinyLlama extracts title, summary, tags.
+4. Agent polls status, retrieves Markdown + metadata JSON for downstream indexing.
+
+---
+
+## 5. Functional Requirements
+
+### 5.1 Format Conversion (source of truth: `shared/formats.py`, [FORMATS.md](FORMATS.md))
+
+- **FR-1.1** Convert between 20+ formats via Pandoc: Markdown/GFM, HTML, DOCX, ODT, RTF, EPUB 2/3, LaTeX, reStructuredText, AsciiDoc, BibTeX, MediaWiki, Jira, and others.
+- **FR-1.2** Validate uploads by magic bytes (PDF `%PDF`, ZIP-based `PK`) and text encoding, not extension alone (`web/validation.py`).
+- **FR-1.3** Enforce limits: 200 MB max upload (`MAX_CONTENT_LENGTH`), 500 MB minimum free disk (`MIN_FREE_SPACE`).
+
+### 5.2 AI PDF→Markdown
+
+- **FR-2.1** `pdf_marker`: Marker AI conversion with layout awareness, table detection, and image extraction. Page limit 600 (`MAX_MARKER_PAGES`); optional `force_ocr` and `use_llm` flags.
+- **FR-2.2** `pdf_hybrid`: try Pandoc first; if output quality is below threshold (currently 50 words/page — see Backlog Epic 1 for the planned quality-score replacement), fall back to Marker.
+- **FR-2.3** `pdf_marker_slm`: Marker followed by SLM refinement of OCR artifacts in 600-word chunks.
+- **FR-2.4** Extracted images are written to an `images/` subdirectory with Markdown references rewritten accordingly; multi-file outputs are zipped on download.
+
+### 5.3 Metadata Extraction (SLM)
+
+- **FR-3.1** After Marker/hybrid success, automatically extract title, summary, and tags via llama-cpp-python (TinyLlama-1.1B by default; configurable via `SLM_MODEL_PATH`).
+- **FR-3.2** Metadata is stored in job metadata and included in webhook payloads.
+- **Known limitation:** context truncated at 2,000 tokens (`MAX_SLM_CONTEXT`) — see Backlog Story 1.6.
+
+### 5.4 Browser Capture Pipeline
+
+- **FR-4.1** Session lifecycle: create → add pages (≤500/session, batches of 50) → finish → assembled document. Session TTL 24 h.
+- **FR-4.2** Each page carries URL, title, text, HTML, and a base64 screenshot; assembly converts screenshot batches to PDF and runs Marker with forced OCR.
+- **FR-4.3** CORS restricted to `chrome-extension://` and `moz-extension://` origins on capture endpoints only.
+
+### 5.5 MCP Server
+
+- **FR-5.1** Internal Node.js service (port 8080) exposing Playwright-driven browser actions, authenticated by `MCP_SECRET` bearer token; reachable only from the worker on the internal network.
+
+### 5.6 Job Lifecycle
+
+- **FR-6.1** Every conversion is an async job (UUID v4) with statuses queued → in_progress → completed/failed, progress percentage, and stage description.
+- **FR-6.2** Real-time updates via Flask-SocketIO; polling via `GET /api/v1/status/{job_id}`.
+- **FR-6.3** Webhooks: registered per-job, fired on completion/failure, 3 retries, SSRF-guarded URL validation, optional HTTPS enforcement (`WEBHOOK_REQUIRE_HTTPS`).
+- **FR-6.4** Retention: outputs deleted 10 min after download, 1 h if never downloaded, 5 min after failure (Celery Beat, `worker/tasks/maintenance.py`).
+- **FR-6.5** Permanently failed tasks land in a Redis dead-letter queue (`dlq:tasks`).
+
+### 5.7 Administration
+
+- **FR-7.1** API key management: create/revoke `dk_` keys via `/api/v1/auth/keys` (admin bearer auth); keys stored hashed (`shared/key_manager.py`).
+- **FR-7.2** Configuration via Pydantic Settings (`config.py`): env vars → `.env` → Docker secrets, with `SecretStr` for sensitive values.
+- **FR-7.3** Health endpoints: `/healthz` (liveness), `/readyz` (readiness), `/api/health` (detailed: Redis, disk, GPU, workers, model cache).
+
+---
+
+## 6. Non-Functional Requirements
+
+### 6.1 Performance
+
+| Metric | Target | Current state |
+|--------|--------|---------------|
+| Pandoc conversion (typical doc) | < 30 s | Met; 500 s subprocess timeout |
+| Marker PDF→Markdown | < 20 min hard limit | 1200 s task limit; throughput unmeasured (Backlog 6.1) |
+| Time-to-first-conversion (cold worker) | < 60 s | ~30 s Marker lazy model load on first job (Backlog 6.2) |
+| Status endpoint latency | p95 < 200 ms | Per `tests/load/locustfile.py` SLA |
+| Conversion request handling | p95 < 2 s (enqueue) | Per locustfile SLA |
+| Error rate under load | < 1% | Per locustfile SLA |
+| Concurrency | 1 conversion at a time per worker | `pool=solo` — head-of-line blocking (Backlog 6.3) |
+
+### 6.2 Security & Privacy
+
+- AES-256-GCM encryption at rest for uploads, outputs, and Redis job metadata.
+- No outbound calls during conversion (model weights fetched at build/startup only).
+- Non-root containers, dropped capabilities, `no-new-privileges`, noexec tmpfs.
+- CSRF protection, rate limiting (1000/day, 200/hour defaults), SSRF guards on webhooks.
+- **Known gaps** (tracked in [BACKLOG.md](BACKLOG.md) Epic 4): Redis TLS disabled, no API key expiration/audit, 8-byte magic validation, MCP container runs as root.
+
+### 6.3 Deployability
+
+- Docker Compose profiles: base, `cpu` (≤3 GB image, no Marker), `gpu` (CUDA 11.8, ~15 GB), `tls`.
+- Kubernetes: namespace, Redis StatefulSet, web/worker Deployments with HPA (1–10 replicas), NetworkPolicies (`deploy/k8s/`).
+- Optional Cloudflare Tunnel ingress for zero-config HTTPS.
+
+### 6.4 Compliance
+
+- NIST SP 800-53 control mappings (AC-2, AC-3, AU-2, SC-8, SC-28) maintained as OSCAL artifacts (`oscal/component-definition.json`, `oscal/ssp.json`), schema-validated in CI (`.github/workflows/oscal-validate.yml`).
+
+### 6.5 Observability
+
+- Prometheus metrics: conversion counts/durations/failures by format, GPU utilization, queue depth (`worker/metrics.py`); Grafana dashboard ([grafana-dashboard.json](grafana-dashboard.json)); alert rules ([ALERTING.md](ALERTING.md)).
+- Structured JSON logging with request-ID correlation in the web tier. **Gap:** worker logs are unstructured (Backlog 3.5).
+
+---
+
+## 7. Quality Bar: Definition of "Good Conversion"
+
+A conversion is *good* when the output preserves: readable body text (no garbage-character runs), document structure (headings at correct levels), tables (well-formed Markdown pipe tables), images (extracted and referenced), and ordering (no shuffled or dropped pages).
+
+**Current state: this bar is not measurable.** The only quality signal in the system is the hybrid engine's 50-words/page heuristic, applied solely to decide Pandoc→Marker fallback. No job carries a quality grade; a degraded output and an excellent output return identical API responses. Making this section enforceable is the purpose of **Backlog Epic 1** (quality scoring in `shared/quality.py`, surfaced through the API).
+
+---
+
+## 8. Success Metrics
+
+| Metric | Definition | Baseline | Target |
+|--------|-----------|----------|--------|
+| Conversion success rate | completed / (completed + failed) | Trackable via `docuflux_conversion_total` | > 98% |
+| Silent-degradation rate | jobs marked completed whose output scores "poor" | **Unmeasurable today** (needs Epic 1) | < 2% |
+| Scanned-PDF support on CPU | scanned PDFs producing readable output on CPU profile | ~0% (no OCR fallback) | > 90% (Epic 2) |
+| p95 job latency by engine | enqueue → completed | Unmeasured (needs Backlog 6.1) | Establish, then improve |
+| Capture session success rate | sessions assembled without page loss | Untracked | > 99% |
+| Security gate coverage | CI gates: lint, SAST, container scan, SBOM | 0 of 4 | 4 of 4 (Epic 5) |
+
+---
+
+## 9. Current State vs Roadmap
+
+### 9.1 Shipped Capabilities
+
+| Capability | Status |
+|------------|--------|
+| Pandoc conversion, 20+ formats | ✅ Shipped |
+| Marker AI PDF→Markdown (GPU) | ✅ Shipped |
+| Hybrid Pandoc→Marker routing | ✅ Shipped (crude heuristic) |
+| SLM metadata extraction | ✅ Shipped (2,000-token window) |
+| Browser extension capture | ✅ Shipped |
+| MCP server (Playwright) | ✅ Shipped |
+| API keys, webhooks, WebSocket progress | ✅ Shipped |
+| Encryption at rest | ✅ Shipped |
+| Prometheus/Grafana observability | ✅ Shipped (web tier structured; worker logs not) |
+| K8s + Compose deployment | ✅ Shipped |
+
+### 9.2 Known Limitations
+
+1. **No OCR on CPU-only deployments** — scanned PDFs are unsupported without a GPU.
+2. **No conversion quality signal** — silent degradation is invisible to clients.
+3. **Single-task worker** (`pool=solo`) — a long Marker job blocks all other work.
+4. **SLM metadata truncation** at 2,000 tokens.
+5. **Redis TLS disabled**; several security-critical modules excluded from test coverage.
+6. **Memory-bound I/O** — downloads and zip generation buffer whole files in RAM.
+
+### 9.3 Roadmap
+
+The prioritized improvement backlog — 6 epics, 31 stories across conversion quality, OCR capability, reliability, hardening, supply-chain, and performance — lives in **[BACKLOG.md](BACKLOG.md)**.
+
+---
+
+## 10. Open Questions & Risks
+
+| # | Question / Risk | Impact |
+|---|-----------------|--------|
+| 1 | CUDA 11.8 approaching EOL — when to migrate the GPU image to CUDA 12.x? | Marker/PyTorch compatibility work |
+| 2 | Should TinyLlama be replaced by a stronger small model (e.g., Qwen/Phi class) for metadata? | Metadata quality vs CPU/VRAM budget |
+| 3 | Is the 600-page Marker limit right? Large books/manuals exceed it. | Capability ceiling for key use cases |
+| 4 | Marker license/upstream cadence — pinned at 1.10.x; upgrade policy undefined. | Supply-chain and quality drift |
+| 5 | Eventlet is in maintenance mode upstream; Flask-SocketIO async-mode migration may be needed. | Web tier rearchitecture risk |
+| 6 | No SLO ownership: metrics exist but no alert thresholds are enforced as commitments. | Operational ambiguity |


### PR DESCRIPTION
## Summary

Adds three product/engineering documents derived from a full repo analysis:

- **docs/PRD.md** — product overview, principles, four personas (self-hoster, API integrator, extension user, MCP/agent consumer), user journeys, functional + non-functional requirements, quality bar, success metrics, and roadmap.
- **docs/ARCHITECTURE.md** — current-state C4 context/container/component views, data-flow sequence diagrams (conversion lifecycle, capture assembly, webhooks), deployment topologies with hardware capability matrix, security architecture with known-gap callouts, and five retroactive ADRs.
- **docs/BACKLOG.md** — prioritized improvement backlog: 6 epics / 31 BDD stories covering PDF→Markdown conversion quality, OCR capability on CPU-only hardware, reliability (fail-loud), security hardening, CI supply-chain gates, and performance/code optimization, with cross-epic dependency mapping and execution order.
- **README.md** — links the three new docs from the Documentation table.

## Verification

- All 9 Mermaid diagrams validated with mermaid-cli (render successfully)
- All relative links between docs resolve; code fences balanced
- All factual claims traced to actual source files (paths cited inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)