### PR TITLE
fix(deps): pin base images by digest, add Dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/mcp_server"
+    schedule:
+      interval: "weekly"

--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -1,5 +1,5 @@
 # Use a Playwright base image which includes Node.js and browser dependencies
-FROM mcr.microsoft.com/playwright:v1.58.2-jammy
+FROM mcr.microsoft.com/playwright:v1.58.2-jammy@sha256:4698a73749c5848d3f5fcd42a2174d172fcad2b2283e087843b115424303a565
 
 WORKDIR /app
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3
 
 # Install curl for healthcheck and libmagic1 for mime type validation
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -7,8 +7,8 @@
 ARG BUILD_GPU=true
 
 # Stage 1: Base image selection (GPU with CUDA or CPU-only Ubuntu)
-FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS base-true
-FROM ubuntu:22.04 AS base-false
+FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04@sha256:8f9dd0d09d3ad3900357a1cf7f887888b5b74056636cd6ef03c160c3cd4b1d95 AS base-true
+FROM ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982 AS base-false
 
 # Select base based on BUILD_GPU argument
 FROM base-${BUILD_GPU} AS base


### PR DESCRIPTION
## Summary
- Pins `python:3.11-slim`, `ubuntu:22.04`, `nvcr.io/nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04`, and `mcr.microsoft.com/playwright:v1.58.2-jammy` by `@sha256` digest — resolved and build-verified against the live registries, so a mutated upstream tag can't silently change what ships.
- Adds a docker-ecosystem Dependabot config for `web/`, `worker/`, and `mcp_server/` to propose future digest bumps.

## Test plan
- [x] `docker build` succeeds for `web/Dockerfile` with the pinned digest
- [x] `docker build` succeeds for `mcp_server/Dockerfile` with the pinned digest
- [x] `docker build --target base-false` succeeds for `worker/Dockerfile` (CPU base)
- [x] `docker manifest inspect` confirms the CUDA digest resolves

Story 5.2 (docs/BACKLOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)