### PR TITLE
ci: add Bandit SAST gate, fail build on high-severity findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,22 @@ jobs:
         name: coverage-report
         path: coverage.xml
 
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Install Bandit
+      run: pip install bandit
+
+    - name: Run Bandit (fail on high severity)
+      run: bandit -r web worker shared -lll
+
   extension-deps:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- New `sast` CI job runs Bandit against `web/`, `worker/`, `shared/` with `-lll` (high severity only), so it's silent on the repo's existing 27 low- and 3 medium-severity findings (0.0.0.0 bind, a hardcoded `/tmp` readiness marker) and only blocks merges on real high-severity issues.

## Test plan
- [x] Verified locally: passes clean on current code (0 high findings)
- [x] Verified locally: fails with exit 1 when a `shell=True` subprocess call is introduced, then reverted the injected code

Story 5.4a (docs/BACKLOG.md, Story 5.4 decomposed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)