### PR TITLE
fix(mcp): run container as non-root pwuser, add HEALTHCHECK

### DIFF
--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -11,8 +11,16 @@ RUN npm install
 # Copy the mcp-server-playwright application code
 COPY . .
 
+# The base image ships a non-root pwuser (uid 1000) already set up for the
+# Playwright browser sandbox; run as that user instead of root.
+RUN chown -R pwuser:pwuser /app
+USER pwuser
+
 # Expose the port that the MCP server will listen on
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
 
 # Command to run the MCP server
 CMD ["npm", "start"]

--- a/mcp_server/server.js
+++ b/mcp_server/server.js
@@ -2,6 +2,7 @@ const { chromium } = require('playwright');
 const http = require('http');
 
 let browser; // Global browser instance
+let ready = false; // True once the browser has finished launching
 
 const MCP_SECRET = process.env.MCP_SECRET;
 if (!MCP_SECRET) {
@@ -35,10 +36,23 @@ function isAllowedUrl(urlStr) {
 async function startBrowser() {
     // Launch browser once and reuse it across requests
     browser = await chromium.launch();
+    ready = true;
     console.log('Playwright browser launched.');
 }
 
 async function handleRequest(req, res) {
+    if (req.method === 'GET' && req.url === '/health') {
+        // Unauthenticated liveness/readiness probe for HEALTHCHECK/orchestrators.
+        if (ready) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'ok' }));
+        } else {
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'starting' }));
+        }
+        return;
+    }
+
     if (req.method === 'POST' && req.url === '/execute') {
         // Authenticate request
         const authHeader = req.headers['authorization'] || '';


### PR DESCRIPTION
## Summary
- The Playwright base image already ships a `pwuser` (uid 1000) set up for the browser sandbox; `mcp_server/Dockerfile` now chowns `/app` to it and switches `USER` before `CMD`.
- Adds an unauthenticated `GET /health` endpoint (200 once the browser has finished launching, 503 during startup) and a Dockerfile `HEALTHCHECK` that curls it.

## Test plan
- [x] Built and ran the image live: process runs as `pwuser` (not root)
- [x] Chromium launches without sandbox/permission errors under `pwuser`
- [x] `HEALTHCHECK` transitions to `healthy`
- [x] Killing the node process crashes the container (exited, connection refused) — orchestrators see it as dead

Story 4.5 (docs/BACKLOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)