### PR TITLE
fix(worker): timeout-safe temp cleanup + orphan sweep for S3 local staging

### DIFF
--- a/shared/storage.py
+++ b/shared/storage.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import logging
 import tempfile
+import time
 from typing import Protocol, Optional, BinaryIO, Iterator, Union, runtime_checkable
 
 
@@ -52,6 +53,8 @@ class StorageBackend(Protocol):
                        folder: str = "output") -> None: ...
 
     def job_dir_exists(self, job_id: str, folder: str = "output") -> bool: ...
+
+    def cleanup_local_stage(self, job_id: str) -> None: ...
 
 
 class LocalStorageBackend:
@@ -156,6 +159,12 @@ class LocalStorageBackend:
 
     def job_dir_exists(self, job_id: str, folder: str = "output") -> bool:
         return os.path.isdir(self._job_path(job_id, folder=folder))
+
+    def cleanup_local_stage(self, job_id: str) -> None:
+        # Local backend's "local path" IS the real upload/output file — deleting
+        # it here would destroy the user's data. Only S3StorageBackend stages a
+        # separate local copy that needs cleanup.
+        pass
 
     def ensure_directories(self) -> None:
         """Create upload and output root directories if they don't exist."""
@@ -353,6 +362,55 @@ class S3StorageBackend:
 
     def job_dir_exists(self, job_id: str, folder: str = "output") -> bool:
         return self.file_exists(job_id, "", folder)
+
+    def _stage_path_for(self, job_id: str) -> Optional[str]:
+        """Resolve job_id's local staging dir, refusing to leave self._temp_dir."""
+        candidate = os.path.abspath(os.path.join(self._temp_dir, job_id))
+        temp_root = os.path.abspath(self._temp_dir)
+        if candidate != temp_root and not candidate.startswith(temp_root + os.sep):
+            logging.error(
+                f"Refusing to touch local stage path outside temp root: "
+                f"job_id={job_id!r} resolved to {candidate}, root is {temp_root}"
+            )
+            return None
+        return candidate
+
+    def cleanup_local_stage(self, job_id: str) -> None:
+        """Remove this job's locally-staged files (downloaded via get_local_path).
+
+        Called from a task's finally block so a soft-timeout or normal
+        completion always frees the local copy. A hard kill of the worker
+        process skips this — sweep_orphaned_local_stage() is the backstop.
+        """
+        path = self._stage_path_for(job_id)
+        if path and os.path.exists(path):
+            shutil.rmtree(path, ignore_errors=True)
+
+    def sweep_orphaned_local_stage(self, max_age_seconds: int) -> int:
+        """Delete locally-staged job directories older than max_age_seconds.
+
+        Backstop for cleanup_local_stage(): catches staged files left behind
+        when a worker is hard-killed mid-task (finally blocks never run).
+        Only ever deletes inside self._temp_dir. Returns count removed.
+        """
+        temp_root = os.path.abspath(self._temp_dir)
+        if not os.path.isdir(temp_root):
+            return 0
+
+        now = time.time()
+        removed = 0
+        for entry in os.listdir(temp_root):
+            path = self._stage_path_for(entry)
+            if not path or not os.path.isdir(path):
+                continue
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                continue
+            if now - mtime > max_age_seconds:
+                shutil.rmtree(path, ignore_errors=True)
+                removed += 1
+        return removed
 
     def ensure_directories(self) -> None:
         # S3 doesn't need directory creation

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import time
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -177,6 +178,13 @@ class TestLocalStorageBackend:
     def test_implements_protocol(self, storage):
         assert isinstance(storage, StorageBackend)
 
+    def test_cleanup_local_stage_is_noop(self, storage):
+        # Local backend's "local path" is the real output file — cleanup_local_stage
+        # must never delete it (only S3StorageBackend stages a separate local copy).
+        storage.save_file("job1", "keep.txt", b"real output", folder="output")
+        storage.cleanup_local_stage("job1")
+        assert storage.file_exists("job1", "keep.txt", folder="output") is True
+
 
 # ── Factory Tests ─────────────────────────────────────────────────────────
 
@@ -337,6 +345,65 @@ class TestS3StorageBackend:
         s3_storage.delete_subpath("job1", "batches", folder="output")
         assert s3_storage.file_exists("job1", "keep.txt", folder="output") is True
         assert s3_storage.file_exists("job1", "batches/batch_0/data.txt", folder="output") is False
+
+    # ── Story 3.3: local-stage cleanup + orphan sweep ───────────────────────
+
+    def test_cleanup_local_stage_removes_local_copy(self, s3_storage):
+        # get_local_path stages a local copy under self._temp_dir for processing.
+        local_path = s3_storage.get_local_path("job1", "file.txt", folder="upload")
+        assert os.path.exists(os.path.dirname(local_path))
+
+        s3_storage.cleanup_local_stage("job1")
+
+        assert not os.path.exists(os.path.dirname(local_path))
+        # The S3 object itself (if any) is untouched — cleanup is local-only.
+
+    def test_cleanup_local_stage_nonexistent_job_is_noop(self, s3_storage):
+        # Should not raise even if nothing was ever staged for this job_id.
+        s3_storage.cleanup_local_stage("never-staged-job")
+
+    def test_cleanup_local_stage_does_not_touch_other_jobs(self, s3_storage):
+        path_a = s3_storage.get_local_path("job-a", "a.txt", folder="upload")
+        path_b = s3_storage.get_local_path("job-b", "b.txt", folder="upload")
+
+        s3_storage.cleanup_local_stage("job-a")
+
+        assert not os.path.exists(os.path.dirname(path_a))
+        assert os.path.exists(os.path.dirname(path_b))
+
+    def test_sweep_orphaned_local_stage_removes_stale_dirs(self, s3_storage):
+        path = s3_storage.get_local_path("stale-job", "f.txt", folder="upload")
+        stage_dir = os.path.dirname(path)
+        old_time = time.time() - 7200  # 2h ago
+        os.utime(stage_dir, (old_time, old_time))
+
+        removed = s3_storage.sweep_orphaned_local_stage(max_age_seconds=3600)
+
+        assert removed == 1
+        assert not os.path.exists(stage_dir)
+
+    def test_sweep_orphaned_local_stage_keeps_recent_dirs(self, s3_storage):
+        path = s3_storage.get_local_path("fresh-job", "f.txt", folder="upload")
+        stage_dir = os.path.dirname(path)
+
+        removed = s3_storage.sweep_orphaned_local_stage(max_age_seconds=3600)
+
+        assert removed == 0
+        assert os.path.exists(stage_dir)
+
+    def test_sweep_orphaned_local_stage_empty_temp_dir(self, s3_storage):
+        assert s3_storage.sweep_orphaned_local_stage(max_age_seconds=3600) == 0
+
+    def test_stage_path_containment_guard_blocks_traversal(self, s3_storage):
+        # A crafted job_id trying to escape the temp root must be refused,
+        # not resolved to a path outside self._temp_dir.
+        outside = s3_storage._stage_path_for("../../etc")
+        assert outside is None
+
+        # cleanup_local_stage must not raise or touch anything outside temp_dir
+        # when handed a traversal-shaped job_id.
+        s3_storage.cleanup_local_stage("../../etc")
+        assert os.path.isdir("/etc")  # sanity: real /etc still exists untouched
 
     def test_job_dir_exists(self, s3_storage):
         assert s3_storage.job_dir_exists("job1", folder="output") is False

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -262,6 +262,81 @@ class TestConvertDocument:
 
         mock_redis.hset.assert_called()
 
+    @patch('tasks.storage.cleanup_local_stage')
+    @patch('tasks.redis_client')
+    @patch('tasks.socketio')
+    @patch('subprocess.run')
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    def test_cleanup_local_stage_called_on_success(
+        self, mock_exists, mock_makedirs, mock_run, mock_socketio,
+        mock_redis, mock_cleanup, sample_job_id
+    ):
+        """Story 3.3: local stage is always released, even on the happy path."""
+        mock_exists.return_value = True
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_redis.hset = MagicMock()
+        mock_redis.hgetall = MagicMock(return_value={})
+
+        tasks.convert_document(
+            job_id=sample_job_id,
+            input_filename='test.md',
+            output_filename='test.html',
+            from_format='markdown',
+            to_format='html'
+        )
+
+        mock_cleanup.assert_called_once()
+
+    @patch('tasks.storage.cleanup_local_stage')
+    @patch('tasks.redis_client')
+    @patch('tasks.socketio')
+    @patch('subprocess.run')
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    def test_cleanup_local_stage_called_on_failure(
+        self, mock_exists, mock_makedirs, mock_run, mock_socketio,
+        mock_redis, mock_cleanup, sample_job_id
+    ):
+        """Story 3.3: local stage is released via finally even when Pandoc fails."""
+        import subprocess
+        mock_exists.return_value = True
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ['pandoc'], stderr="pandoc: unknown format")
+        mock_pipe = MagicMock()
+        mock_redis.pipeline.return_value = mock_pipe
+        mock_pipe.execute.return_value = [1, {}]
+
+        with pytest.raises(Exception, match="Pandoc failed"):
+            tasks.convert_document(
+                job_id=sample_job_id,
+                input_filename='test.md',
+                output_filename='test.html',
+                from_format='markdown',
+                to_format='html'
+            )
+
+        mock_cleanup.assert_called_once()
+
+    @patch('tasks.storage.cleanup_local_stage')
+    @patch('tasks.redis_client')
+    @patch('tasks.socketio')
+    @patch('os.path.exists')
+    def test_cleanup_local_stage_not_called_before_job_id_resolved(
+        self, mock_exists, mock_socketio, mock_redis, mock_cleanup
+    ):
+        """Invalid job_id returns before any local stage exists — nothing to clean up."""
+        result = tasks.convert_document(
+            job_id='not-a-uuid',
+            input_filename='test.md',
+            output_filename='test.html',
+            from_format='markdown',
+            to_format='html'
+        )
+
+        assert result['status'] == 'error'
+        mock_cleanup.assert_not_called()
+
 
 # ============================================================
 # convert_with_marker tests (Marker AI - uses PdfConverter API)
@@ -576,6 +651,31 @@ class TestCleanupOldFiles:
             tasks.cleanup_old_files()
 
         mock_rmtree.assert_not_called()
+
+
+# ============================================================
+# Story 3.3: orphaned local-stage sweep tests
+# ============================================================
+
+class TestSweepOrphanedTempFiles:
+
+    def test_delegates_to_storage_sweep_method(self):
+        """When the backend exposes sweep_orphaned_local_stage, it's called
+        with the 1h age threshold and its return value is passed through."""
+        mock_sweep = MagicMock(return_value=3)
+        with patch.object(tasks.storage, 'sweep_orphaned_local_stage', mock_sweep, create=True):
+            result = tasks.sweep_orphaned_temp_files()
+
+        mock_sweep.assert_called_once_with(3600)
+        assert result == 3
+
+    def test_noop_when_backend_has_no_sweep_method(self):
+        """LocalStorageBackend has no sweep_orphaned_local_stage — must not raise."""
+        # tasks.storage in this test module is a real LocalStorageBackend,
+        # which intentionally does not define sweep_orphaned_local_stage.
+        assert not hasattr(tasks.storage, 'sweep_orphaned_local_stage')
+        result = tasks.sweep_orphaned_temp_files()
+        assert result == 0
 
 
 # ============================================================

--- a/worker/tasks/__init__.py
+++ b/worker/tasks/__init__.py
@@ -159,7 +159,7 @@ from tasks import metadata    # noqa: E402, F401
 # Re-export task functions for backward compatibility
 from tasks.conversion import convert_document, convert_with_marker, convert_with_marker_slm, convert_with_hybrid
 from tasks.capture import analyze_screenshot_layout, agentic_page_turner, process_capture_batch, assemble_capture_session
-from tasks.maintenance import cleanup_old_files, migrate_filesystem_jobs, update_metrics
+from tasks.maintenance import cleanup_old_files, migrate_filesystem_jobs, update_metrics, sweep_orphaned_temp_files
 from tasks.metadata import extract_slm_metadata, test_amazon_session
 
 # Re-export helpers so @patch('tasks.xxx') in tests still works
@@ -182,6 +182,11 @@ celery.conf.beat_schedule = {
     'update-queue-metrics': {
         'task': 'tasks.update_metrics',
         'schedule': 120.0,
+        'options': {'queue': 'default'},
+    },
+    'sweep-orphaned-temp-files': {
+        'task': 'tasks.sweep_orphaned_temp_files',
+        'schedule': 900.0,
         'options': {'queue': 'default'},
     },
 }

--- a/worker/tasks/capture.py
+++ b/worker/tasks/capture.py
@@ -85,6 +85,7 @@ def analyze_screenshot_layout(job_id, url, storage_state_json=None):
         if temp_screenshot_path and os.path.exists(temp_screenshot_path):
             os.remove(temp_screenshot_path)
             logging.info(f"Cleaned up temporary screenshot: {temp_screenshot_path}")
+        _pkg.storage.cleanup_local_stage(job_id)
 
 
 @_pkg.celery.task(
@@ -556,3 +557,5 @@ def assemble_capture_session(session_id, job_id):
         })
         _pkg.redis_client.expire(f"job:{job_id}", 600)
         raise
+    finally:
+        _pkg.storage.cleanup_local_stage(job_id)

--- a/worker/tasks/conversion.py
+++ b/worker/tasks/conversion.py
@@ -211,80 +211,86 @@ def convert_document(job_id, input_filename, output_filename, from_format, to_fo
         worker_tasks_active.dec()
         raise
 
-    if not _pkg.storage.file_exists(safe_job_id, safe_input_filename, folder='upload'):
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
-        raise FileNotFoundError(f"Input file not found: {input_path}")
-
-    _pkg.storage.makedirs(safe_job_id, folder='output')
-    _pkg.update_job_metadata(job_id, {'progress': '20', 'stage': 'Converting document'})
-
-    cmd = build_pandoc_cmd(from_format, to_format, input_path, output_path, pandoc_options)
-
     try:
-        process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=500)
-        logging.info(f"Conversion successful: {output_path}")
+        if not _pkg.storage.file_exists(safe_job_id, safe_input_filename, folder='upload'):
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
+            raise FileNotFoundError(f"Input file not found: {input_path}")
 
-        _pkg.update_job_metadata(job_id, {
-            'status': 'SUCCESS',
-            'completed_at': str(time.time()),
-            'progress': '100',
-            'encrypted': 'false',
-            'file_count': '1',
-            'stage': 'Complete'
-        })
-        _pkg.redis_client.expire(f"job:{job_id}", 7200)
-        _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
+        _pkg.storage.makedirs(safe_job_id, folder='output')
+        _pkg.update_job_metadata(job_id, {'progress': '20', 'stage': 'Converting document'})
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+        cmd = build_pandoc_cmd(from_format, to_format, input_path, output_path, pandoc_options)
 
-        import gc
-        gc.collect()
+        try:
+            process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=500)
+            logging.info(f"Conversion successful: {output_path}")
 
-        return {"status": "success", "output_file": os.path.basename(output_path)}
-    except subprocess.TimeoutExpired:
-        error_msg = "Conversion timed out after 500 seconds"
-        logging.error(f"Timeout for job {job_id}: {error_msg}")
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': error_msg, 'progress': '0', 'stage': 'Failed'})
-        _pkg.redis_client.expire(f"job:{job_id}", 600)
-        _pkg.fire_webhook(job_id, 'FAILURE', {'error': error_msg})
+            _pkg.update_job_metadata(job_id, {
+                'status': 'SUCCESS',
+                'completed_at': str(time.time()),
+                'progress': '100',
+                'encrypted': 'false',
+                'file_count': '1',
+                'stage': 'Complete'
+            })
+            _pkg.redis_client.expire(f"job:{job_id}", 7200)
+            _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
-        conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='timeout').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
 
-        raise Exception(error_msg)
-    except subprocess.CalledProcessError as e:
-        error_msg = e.stderr or e.stdout or "Unknown error"
-        logging.error(f"Pandoc error for job {job_id}: {error_msg}")
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(error_msg)[:500], 'progress': '0', 'stage': 'Failed'})
-        _pkg.redis_client.expire(f"job:{job_id}", 600)
-        _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(error_msg)[:500]})
+            import gc
+            gc.collect()
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
-        conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='pandoc_error').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+            return {"status": "success", "output_file": os.path.basename(output_path)}
+        except subprocess.TimeoutExpired:
+            error_msg = "Conversion timed out after 500 seconds"
+            logging.error(f"Timeout for job {job_id}: {error_msg}")
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': error_msg, 'progress': '0', 'stage': 'Failed'})
+            _pkg.redis_client.expire(f"job:{job_id}", 600)
+            _pkg.fire_webhook(job_id, 'FAILURE', {'error': error_msg})
 
-        raise Exception(f"Pandoc failed: {error_msg}")
-    except Exception as e:
-        logging.error(f"Unexpected error for job {job_id}: {str(e)}")
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
-        _pkg.redis_client.expire(f"job:{job_id}", 600)
-        _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
+            conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='timeout').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
-        conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='unknown').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+            raise Exception(error_msg)
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr or e.stdout or "Unknown error"
+            logging.error(f"Pandoc error for job {job_id}: {error_msg}")
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(error_msg)[:500], 'progress': '0', 'stage': 'Failed'})
+            _pkg.redis_client.expire(f"job:{job_id}", 600)
+            _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(error_msg)[:500]})
 
-        raise
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
+            conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='pandoc_error').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+
+            raise Exception(f"Pandoc failed: {error_msg}")
+        except Exception as e:
+            logging.error(f"Unexpected error for job {job_id}: {str(e)}")
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
+            _pkg.redis_client.expire(f"job:{job_id}", 600)
+            _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
+
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
+            conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='unknown').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+
+            raise
+    finally:
+        # Story 3.3: always release the locally-staged input/output copies
+        # (no-op for LocalStorageBackend; frees S3StorageBackend's temp
+        # staging dir even on soft-timeout or any exception above).
+        _pkg.storage.cleanup_local_stage(safe_job_id)
 
 
 @_pkg.celery.task(
@@ -323,61 +329,64 @@ def convert_with_marker(self, job_id, input_filename, output_filename, from_form
     logging.info(f"Starting Marker conversion for job {job_id} (Attempt {self.request.retries + 1}) with options: {options}")
     _pkg.update_job_metadata(job_id, {'status': 'PROCESSING', 'started_at': str(time.time()), 'progress': '5', 'stage': 'Preparing conversion'})
 
-    if not _pkg.storage.file_exists(safe_job_id, safe_input, folder='upload'):
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
-        raise FileNotFoundError(f"Input file not found: {input_path}")
-
     try:
-        _pkg._check_pdf_page_limit(job_id, input_path, _pkg.app_settings.max_marker_pages)
-    except PageLimitExceeded:
-        worker_tasks_active.dec()
-        raise
+        if not _pkg.storage.file_exists(safe_job_id, safe_input, folder='upload'):
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
+            raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    _pkg.storage.makedirs(safe_job_id, folder='output')
-    images_dir = _pkg.storage.get_local_path(safe_job_id, 'images', folder='output')
-    _pkg.storage.makedirs(safe_job_id, 'images', folder='output')
+        try:
+            _pkg._check_pdf_page_limit(job_id, input_path, _pkg.app_settings.max_marker_pages)
+        except PageLimitExceeded:
+            worker_tasks_active.dec()
+            raise
 
-    converter = rendered = text = images = None
-    try:
-        _pkg.update_job_metadata(job_id, {'progress': '15', 'stage': 'Converting PDF with AI'})
-        converter, rendered = _pkg._run_marker(input_path, options or {})
+        _pkg.storage.makedirs(safe_job_id, folder='output')
+        images_dir = _pkg.storage.get_local_path(safe_job_id, 'images', folder='output')
+        _pkg.storage.makedirs(safe_job_id, 'images', folder='output')
 
-        _pkg.update_job_metadata(job_id, {'progress': '80', 'stage': 'Saving extracted content'})
-        text, images, _, file_count = _pkg._save_marker_output(rendered, output_path, images_dir)
+        converter = rendered = text = images = None
+        try:
+            _pkg.update_job_metadata(job_id, {'progress': '15', 'stage': 'Converting PDF with AI'})
+            converter, rendered = _pkg._run_marker(input_path, options or {})
 
-        _pkg.update_job_metadata(job_id, {'progress': '90', 'file_count': str(file_count), 'stage': 'Finalizing output'})
-        logging.info(f"Marker conversion successful: {output_path}")
+            _pkg.update_job_metadata(job_id, {'progress': '80', 'stage': 'Saving extracted content'})
+            text, images, _, file_count = _pkg._save_marker_output(rendered, output_path, images_dir)
 
-        _pkg.update_job_metadata(job_id, {
-            'status': 'SUCCESS', 'completed_at': str(time.time()),
-            'progress': '100', 'encrypted': 'false', 'stage': 'Complete'
-        })
-        _pkg.redis_client.expire(f"job:{job_id}", 7200)
-        _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
-        _pkg.extract_slm_metadata.delay(job_id, output_path)
+            _pkg.update_job_metadata(job_id, {'progress': '90', 'file_count': str(file_count), 'stage': 'Finalizing output'})
+            logging.info(f"Marker conversion successful: {output_path}")
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+            _pkg.update_job_metadata(job_id, {
+                'status': 'SUCCESS', 'completed_at': str(time.time()),
+                'progress': '100', 'encrypted': 'false', 'stage': 'Complete'
+            })
+            _pkg.redis_client.expire(f"job:{job_id}", 7200)
+            _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
+            _pkg.extract_slm_metadata.delay(job_id, output_path)
 
-        _pkg._cleanup_marker_memory(converter, rendered, text, images)
-        return {"status": "success", "output_file": os.path.basename(output_path)}
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
 
-    except Exception as e:
-        logging.error(f"Marker error for job {job_id}: {e}")
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
-        _pkg.redis_client.expire(f"job:{job_id}", 600)
-        _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
+            _pkg._cleanup_marker_memory(converter, rendered, text, images)
+            return {"status": "success", "output_file": os.path.basename(output_path)}
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
-        conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='marker_error').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+        except Exception as e:
+            logging.error(f"Marker error for job {job_id}: {e}")
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
+            _pkg.redis_client.expire(f"job:{job_id}", 600)
+            _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
 
-        _pkg._cleanup_marker_memory(converter, rendered, text, images)
-        raise
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
+            conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='marker_error').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+
+            _pkg._cleanup_marker_memory(converter, rendered, text, images)
+            raise
+    finally:
+        _pkg.storage.cleanup_local_stage(safe_job_id)
 
 
 @_pkg.celery.task(
@@ -417,69 +426,72 @@ def convert_with_marker_slm(self, job_id, input_filename, output_filename,
     logging.info(f"Starting Marker+SLM conversion for job {job_id} with options: {options}")
     _pkg.update_job_metadata(job_id, {'status': 'PROCESSING', 'started_at': str(time.time()), 'progress': '5', 'stage': 'Preparing conversion'})
 
-    if not _pkg.storage.file_exists(safe_job_id, safe_input, folder='upload'):
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
-        raise FileNotFoundError(f"Input file not found: {input_path}")
-
     try:
-        _pkg._check_pdf_page_limit(job_id, input_path, _pkg.app_settings.max_marker_pages)
-    except PageLimitExceeded:
-        worker_tasks_active.dec()
-        raise
+        if not _pkg.storage.file_exists(safe_job_id, safe_input, folder='upload'):
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
+            raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    _pkg.storage.makedirs(safe_job_id, folder='output')
-    images_dir = _pkg.storage.get_local_path(safe_job_id, 'images', folder='output')
-    _pkg.storage.makedirs(safe_job_id, 'images', folder='output')
+        try:
+            _pkg._check_pdf_page_limit(job_id, input_path, _pkg.app_settings.max_marker_pages)
+        except PageLimitExceeded:
+            worker_tasks_active.dec()
+            raise
 
-    converter = rendered = text = images = None
-    try:
-        _pkg.update_job_metadata(job_id, {'progress': '15', 'stage': 'Converting PDF with AI'})
-        converter, rendered = _pkg._run_marker(input_path, options or {})
+        _pkg.storage.makedirs(safe_job_id, folder='output')
+        images_dir = _pkg.storage.get_local_path(safe_job_id, 'images', folder='output')
+        _pkg.storage.makedirs(safe_job_id, 'images', folder='output')
 
-        _pkg.update_job_metadata(job_id, {'progress': '50', 'stage': 'Saving AI conversion output'})
-        text, images, _, file_count = _pkg._save_marker_output(rendered, output_path, images_dir)
+        converter = rendered = text = images = None
+        try:
+            _pkg.update_job_metadata(job_id, {'progress': '15', 'stage': 'Converting PDF with AI'})
+            converter, rendered = _pkg._run_marker(input_path, options or {})
 
-        _pkg._cleanup_marker_memory(converter, rendered)
-        converter = rendered = None
+            _pkg.update_job_metadata(job_id, {'progress': '50', 'stage': 'Saving AI conversion output'})
+            text, images, _, file_count = _pkg._save_marker_output(rendered, output_path, images_dir)
 
-        logging.info(f"[{job_id}] Starting SLM refinement pass")
-        refined_text = _pkg._slm_refine_markdown(text, job_id)
-        with open(output_path, 'w', encoding='utf-8') as f:
-            f.write(refined_text)
+            _pkg._cleanup_marker_memory(converter, rendered)
+            converter = rendered = None
 
-        _pkg.update_job_metadata(job_id, {'progress': '95', 'file_count': str(file_count), 'stage': 'Finalizing output'})
-        logging.info(f"Marker+SLM conversion successful: {output_path}")
+            logging.info(f"[{job_id}] Starting SLM refinement pass")
+            refined_text = _pkg._slm_refine_markdown(text, job_id)
+            with open(output_path, 'w', encoding='utf-8') as f:
+                f.write(refined_text)
 
-        _pkg.update_job_metadata(job_id, {
-            'status': 'SUCCESS', 'completed_at': str(time.time()),
-            'progress': '100', 'encrypted': 'false', 'stage': 'Complete'
-        })
-        _pkg.redis_client.expire(f"job:{job_id}", 7200)
-        _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
-        _pkg.extract_slm_metadata.delay(job_id, output_path)
+            _pkg.update_job_metadata(job_id, {'progress': '95', 'file_count': str(file_count), 'stage': 'Finalizing output'})
+            logging.info(f"Marker+SLM conversion successful: {output_path}")
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+            _pkg.update_job_metadata(job_id, {
+                'status': 'SUCCESS', 'completed_at': str(time.time()),
+                'progress': '100', 'encrypted': 'false', 'stage': 'Complete'
+            })
+            _pkg.redis_client.expire(f"job:{job_id}", 7200)
+            _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
+            _pkg.extract_slm_metadata.delay(job_id, output_path)
 
-        _pkg._cleanup_marker_memory(text, images)
-        return {"status": "success", "output_file": os.path.basename(output_path)}
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
 
-    except Exception as e:
-        logging.error(f"Marker+SLM error for job {job_id}: {e}")
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
-        _pkg.redis_client.expire(f"job:{job_id}", 600)
-        _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
+            _pkg._cleanup_marker_memory(text, images)
+            return {"status": "success", "output_file": os.path.basename(output_path)}
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
-        conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='marker_slm_error').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
+        except Exception as e:
+            logging.error(f"Marker+SLM error for job {job_id}: {e}")
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
+            _pkg.redis_client.expire(f"job:{job_id}", 600)
+            _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
 
-        _pkg._cleanup_marker_memory(converter, rendered, text, images)
-        raise
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
+            conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='marker_slm_error').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+
+            _pkg._cleanup_marker_memory(converter, rendered, text, images)
+            raise
+    finally:
+        _pkg.storage.cleanup_local_stage(safe_job_id)
 
 
 @_pkg.celery.task(
@@ -518,98 +530,101 @@ def convert_with_hybrid(self, job_id, input_filename, output_filename, from_form
     logging.info(f"Starting hybrid conversion for job {job_id}")
     _pkg.update_job_metadata(job_id, {'status': 'PROCESSING', 'started_at': str(time.time()), 'progress': '5', 'stage': 'Preparing conversion'})
 
-    if not _pkg.storage.file_exists(safe_job_id, safe_input, folder='upload'):
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
-        worker_tasks_active.dec()
-        raise FileNotFoundError(f"Input file not found: {input_path}")
-
-    _pkg.storage.makedirs(safe_job_id, folder='output')
-
-    # Get PDF page count
-    page_count = 1
     try:
-        import pypdfium2 as pdfium
-        pdf_doc = pdfium.PdfDocument(input_path)
-        page_count = len(pdf_doc)
-        pdf_doc.close()
-        _pkg.update_job_metadata(job_id, {'page_count': str(page_count)})
-    except Exception as e:
-        logging.warning(f"Could not get page count: {e}")
+        if not _pkg.storage.file_exists(safe_job_id, safe_input, folder='upload'):
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': 'Input file missing'})
+            worker_tasks_active.dec()
+            raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    # Try Pandoc fast path
-    _pkg.update_job_metadata(job_id, {'progress': '15', 'hybrid_engine_used': 'pandoc', 'stage': 'Trying fast conversion'})
-    pandoc_ok = False
-    try:
-        cmd = ['pandoc', '-f', 'pdf', '-t', 'markdown', input_path, '-o', output_path]
-        subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
-        pandoc_ok = _pkg._assess_pandoc_quality(output_path, page_count)
+        _pkg.storage.makedirs(safe_job_id, folder='output')
+
+        # Get PDF page count
+        page_count = 1
+        try:
+            import pypdfium2 as pdfium
+            pdf_doc = pdfium.PdfDocument(input_path)
+            page_count = len(pdf_doc)
+            pdf_doc.close()
+            _pkg.update_job_metadata(job_id, {'page_count': str(page_count)})
+        except Exception as e:
+            logging.warning(f"Could not get page count: {e}")
+
+        # Try Pandoc fast path
+        _pkg.update_job_metadata(job_id, {'progress': '15', 'hybrid_engine_used': 'pandoc', 'stage': 'Trying fast conversion'})
+        pandoc_ok = False
+        try:
+            cmd = ['pandoc', '-f', 'pdf', '-t', 'markdown', input_path, '-o', output_path]
+            subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
+            pandoc_ok = _pkg._assess_pandoc_quality(output_path, page_count)
+            if pandoc_ok:
+                logging.info(f"Hybrid job {job_id}: Pandoc output is high quality, done.")
+        except Exception as e:
+            logging.info(f"Hybrid job {job_id}: Pandoc attempt failed ({e}), trying Marker.")
+
+        _pkg.update_job_metadata(job_id, {'progress': '40', 'stage': 'Checking conversion quality'})
+
         if pandoc_ok:
-            logging.info(f"Hybrid job {job_id}: Pandoc output is high quality, done.")
-    except Exception as e:
-        logging.info(f"Hybrid job {job_id}: Pandoc attempt failed ({e}), trying Marker.")
+            _pkg.update_job_metadata(job_id, {
+                'status': 'SUCCESS', 'completed_at': str(time.time()),
+                'progress': '100', 'encrypted': 'false', 'file_count': '1',
+                'hybrid_engine_used': 'pandoc', 'stage': 'Complete'
+            })
+            _pkg.redis_client.expire(f"job:{job_id}", 7200)
+            _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
+            _pkg.extract_slm_metadata.delay(job_id, output_path)
 
-    _pkg.update_job_metadata(job_id, {'progress': '40', 'stage': 'Checking conversion quality'})
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+            import gc; gc.collect()
+            return {"status": "success", "output_file": os.path.basename(output_path), "engine": "pandoc"}
 
-    if pandoc_ok:
-        _pkg.update_job_metadata(job_id, {
-            'status': 'SUCCESS', 'completed_at': str(time.time()),
-            'progress': '100', 'encrypted': 'false', 'file_count': '1',
-            'hybrid_engine_used': 'pandoc', 'stage': 'Complete'
-        })
-        _pkg.redis_client.expire(f"job:{job_id}", 7200)
-        _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
-        _pkg.extract_slm_metadata.delay(job_id, output_path)
+        # Fall back to Marker AI
+        try:
+            _pkg._check_pdf_page_limit(job_id, input_path, _pkg.app_settings.max_marker_pages)
+        except PageLimitExceeded:
+            worker_tasks_active.dec()
+            raise
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
-        import gc; gc.collect()
-        return {"status": "success", "output_file": os.path.basename(output_path), "engine": "pandoc"}
+        images_dir = _pkg.storage.get_local_path(safe_job_id, 'images', folder='output')
+        _pkg.storage.makedirs(safe_job_id, 'images', folder='output')
 
-    # Fall back to Marker AI
-    try:
-        _pkg._check_pdf_page_limit(job_id, input_path, _pkg.app_settings.max_marker_pages)
-    except PageLimitExceeded:
-        worker_tasks_active.dec()
-        raise
+        _pkg.update_job_metadata(job_id, {'progress': '50', 'hybrid_engine_used': 'marker', 'stage': 'Converting PDF with AI'})
+        converter = rendered = text = images = None
+        try:
+            converter, rendered = _pkg._run_marker(input_path, options or {})
+            _pkg.update_job_metadata(job_id, {'progress': '85', 'stage': 'Saving extracted content'})
+            text, images, _, file_count = _pkg._save_marker_output(rendered, output_path, images_dir)
 
-    images_dir = _pkg.storage.get_local_path(safe_job_id, 'images', folder='output')
-    _pkg.storage.makedirs(safe_job_id, 'images', folder='output')
+            _pkg.update_job_metadata(job_id, {
+                'status': 'SUCCESS', 'completed_at': str(time.time()),
+                'progress': '100', 'encrypted': 'false', 'file_count': str(file_count),
+                'hybrid_engine_used': 'marker', 'stage': 'Complete'
+            })
+            _pkg.redis_client.expire(f"job:{job_id}", 7200)
+            _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
+            _pkg.extract_slm_metadata.delay(job_id, output_path)
 
-    _pkg.update_job_metadata(job_id, {'progress': '50', 'hybrid_engine_used': 'marker', 'stage': 'Converting PDF with AI'})
-    converter = rendered = text = images = None
-    try:
-        converter, rendered = _pkg._run_marker(input_path, options or {})
-        _pkg.update_job_metadata(job_id, {'progress': '85', 'stage': 'Saving extracted content'})
-        text, images, _, file_count = _pkg._save_marker_output(rendered, output_path, images_dir)
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+            _pkg._cleanup_marker_memory(converter, rendered, text, images)
+            return {"status": "success", "output_file": os.path.basename(output_path), "engine": "marker"}
 
-        _pkg.update_job_metadata(job_id, {
-            'status': 'SUCCESS', 'completed_at': str(time.time()),
-            'progress': '100', 'encrypted': 'false', 'file_count': str(file_count),
-            'hybrid_engine_used': 'marker', 'stage': 'Complete'
-        })
-        _pkg.redis_client.expire(f"job:{job_id}", 7200)
-        _pkg.fire_webhook(job_id, 'SUCCESS', {'download_url': f'/api/v1/download/{job_id}'})
-        _pkg.extract_slm_metadata.delay(job_id, output_path)
+        except Exception as e:
+            logging.error(f"Hybrid Marker fallback error for job {job_id}: {e}")
+            _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
+            _pkg.redis_client.expire(f"job:{job_id}", 600)
+            _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
 
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='success').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
-        _pkg._cleanup_marker_memory(converter, rendered, text, images)
-        return {"status": "success", "output_file": os.path.basename(output_path), "engine": "marker"}
-
-    except Exception as e:
-        logging.error(f"Hybrid Marker fallback error for job {job_id}: {e}")
-        _pkg.update_job_metadata(job_id, {'status': 'FAILURE', 'completed_at': str(time.time()), 'error': str(e)[:500], 'progress': '0', 'stage': 'Failed'})
-        _pkg.redis_client.expire(f"job:{job_id}", 600)
-        _pkg.fire_webhook(job_id, 'FAILURE', {'error': str(e)[:500]})
-
-        duration = time.time() - start_time
-        conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
-        conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='hybrid_error').inc()
-        conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
-        worker_tasks_active.dec()
-        _pkg._cleanup_marker_memory(converter, rendered, text, images)
-        raise
+            duration = time.time() - start_time
+            conversion_total.labels(format_from=from_format, format_to=to_format, status='failure').inc()
+            conversion_failures_total.labels(format_from=from_format, format_to=to_format, error_type='hybrid_error').inc()
+            conversion_duration_seconds.labels(format_from=from_format, format_to=to_format).observe(duration)
+            worker_tasks_active.dec()
+            _pkg._cleanup_marker_memory(converter, rendered, text, images)
+            raise
+    finally:
+        _pkg.storage.cleanup_local_stage(safe_job_id)

--- a/worker/tasks/maintenance.py
+++ b/worker/tasks/maintenance.py
@@ -172,6 +172,28 @@ def cleanup_old_files():
         logging.warning(f"Error cleaning up capture session keys: {e}")
 
 
+@_pkg.celery.task(name='tasks.sweep_orphaned_temp_files')
+def sweep_orphaned_temp_files():
+    """Story 3.3 backstop: remove S3StorageBackend local-staging directories
+    left behind by a hard-killed worker (finally blocks never ran).
+
+    No-op for LocalStorageBackend — cleanup_local_stage() there is a no-op
+    too, since local backend's "local path" is the real file, not a stage.
+    sweep_orphaned_local_stage() only ever deletes inside the backend's own
+    temp root (see S3StorageBackend._stage_path_for's containment check).
+    """
+    ORPHAN_STAGE_MAX_AGE = 3600  # 1h — generous vs. the longest task time_limit (1800s)
+
+    sweep = getattr(_pkg.storage, 'sweep_orphaned_local_stage', None)
+    if sweep is None:
+        return 0
+
+    removed = sweep(ORPHAN_STAGE_MAX_AGE)
+    if removed:
+        logging.info(f"Orphan sweep: removed {removed} stale local-stage director(y/ies)")
+    return removed
+
+
 @_pkg.celery.task(name='tasks.migrate_filesystem_jobs')
 def migrate_filesystem_jobs():
     """One-time migration: register filesystem jobs into Redis sorted set.


### PR DESCRIPTION
## Summary
- `S3StorageBackend.get_local_path()` stages files under a per-process `tempfile.mkdtemp()` dir that was never cleaned up — every conversion/capture task on S3 storage leaked a local copy forever. (Local storage doesn't have this problem — its "local path" IS the real upload/output file.)
- Adds `cleanup_local_stage(job_id)` (no-op on Local, real delete on S3) and wraps the four conversion tasks + two capture tasks that call `get_local_path()` in try/finally so it always runs.
- Adds `sweep_orphaned_local_stage()` plus a beat-scheduled `tasks.sweep_orphaned_temp_files` (every 15m) as a backstop for hard worker kills, with a containment guard so it can never delete outside the backend's own temp root.

## Test plan
- [x] 8 new storage-level tests incl. a path-traversal containment-guard case
- [x] 3 new tests on `convert_document`'s success/failure/early-return paths
- [x] 2 new tests on the sweep task
- [x] Full existing `tests/unit/` suite: 264 passed vs. 251 baseline on unmodified main (same pre-existing unrelated `test_web.py` env errors on both)

Story 3.3 (docs/BACKLOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)