### PR TITLE
feat(worker): head+tail sampling for SLM metadata on long documents

### DIFF
--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1580,6 +1580,56 @@ class TestAssessPandocQuality:
         assert result is False
 
 
+class TestSampleForSlmContext:
+    """Tests for the _sample_for_slm_context helper (Story 1.6)."""
+
+    def test_short_document_passes_through_unchanged(self):
+        """Alternative path: content within the limit is used directly, no sampling."""
+        content = " ".join(["word"] * 500)
+        sampled, was_sampled = tasks._sample_for_slm_context(content, max_words=2000)
+        assert sampled == content
+        assert was_sampled is False
+
+    def test_document_at_exact_limit_passes_through_unchanged(self):
+        content = " ".join(["word"] * 2000)
+        sampled, was_sampled = tasks._sample_for_slm_context(content, max_words=2000)
+        assert sampled == content
+        assert was_sampled is False
+
+    def test_long_document_samples_head_and_tail(self):
+        """Happy path: both the start and the end of the document inform the sample."""
+        words = [f"w{i}" for i in range(5000)]
+        content = " ".join(words)
+        sampled, was_sampled = tasks._sample_for_slm_context(content, max_words=2000)
+
+        assert was_sampled is True
+        assert "w0" in sampled  # head present
+        assert "w4999" in sampled  # tail present
+        assert "w2500" not in sampled  # omitted middle is actually omitted
+
+    def test_sampled_output_is_bounded_regardless_of_input_size(self):
+        """Boundary: sample size stays ~max_words even for a very long document,
+        so a single SLM call's latency doesn't grow with document length."""
+        short_sample, _ = tasks._sample_for_slm_context(" ".join(["w"] * 5000), max_words=2000)
+        long_sample, _ = tasks._sample_for_slm_context(" ".join(["w"] * 500000), max_words=2000)
+
+        # Both samples are drawn from the same fixed word budget (+ a short
+        # separator), independent of how much longer the second document is.
+        assert abs(len(short_sample.split()) - len(long_sample.split())) <= 5
+
+    def test_title_only_in_tail_is_reachable(self):
+        """Business rule: a title-bearing sentence past the old fixed 2000-word
+        cutoff is present in the sample, unlike naive head-only truncation."""
+        filler = " ".join(["filler"] * 2500)
+        content = f"{filler} The Real Title Is Here At The End"
+        sampled, _ = tasks._sample_for_slm_context(content, max_words=2000)
+
+        assert "The Real Title Is Here At The End" in sampled
+        # Naive head-only truncation to 2000 words would have missed it entirely.
+        naive_truncation = " ".join(content.split()[:2000])
+        assert "The Real Title Is Here At The End" not in naive_truncation
+
+
 class TestConvertWithHybrid:
     """Tests for the convert_with_hybrid Celery task."""
 

--- a/worker/tasks/__init__.py
+++ b/worker/tasks/__init__.py
@@ -175,7 +175,7 @@ from tasks import metadata    # noqa: E402, F401
 from tasks.conversion import convert_document, convert_with_marker, convert_with_marker_slm, convert_with_hybrid, convert_with_ocr
 from tasks.capture import analyze_screenshot_layout, agentic_page_turner, process_capture_batch, assemble_capture_session
 from tasks.maintenance import cleanup_old_files, migrate_filesystem_jobs, update_metrics, sweep_orphaned_temp_files
-from tasks.metadata import extract_slm_metadata, test_amazon_session
+from tasks.metadata import extract_slm_metadata, test_amazon_session, _sample_for_slm_context
 
 # Re-export helpers so @patch('tasks.xxx') in tests still works
 from tasks.conversion import (

--- a/worker/tasks/metadata.py
+++ b/worker/tasks/metadata.py
@@ -32,6 +32,28 @@ def _parse_slm_json(generated_text):
     return metadata
 
 
+def _sample_for_slm_context(markdown_content, max_words, head_ratio=0.6):
+    """Select representative content for SLM inference, bounded to max_words.
+
+    Documents at or under max_words pass through unchanged. Longer documents
+    are sampled from both the head and the tail (rather than naive
+    head-only truncation) so a title or key fact that only appears late in
+    a long document — past the old fixed 2000-word cutoff — still reaches
+    the SLM. The total sampled size stays fixed at max_words regardless of
+    document length, so SLM call latency doesn't grow with document size.
+    """
+    words = markdown_content.split()
+    if len(words) <= max_words:
+        return markdown_content, False
+
+    head_words = int(max_words * head_ratio)
+    tail_words = max_words - head_words
+    head = " ".join(words[:head_words])
+    tail = " ".join(words[-tail_words:]) if tail_words > 0 else ""
+    sampled = f"{head}\n\n[... content omitted ...]\n\n{tail}" if tail else head
+    return sampled, True
+
+
 @_pkg.celery.task(
     name='tasks.extract_slm_metadata',
     time_limit=300,
@@ -62,9 +84,13 @@ def extract_slm_metadata(job_id, markdown_file_path):
             markdown_content = f.read()
 
         MAX_SLM_CONTEXT = _pkg.app_settings.max_slm_context
-        if len(markdown_content.split()) > MAX_SLM_CONTEXT:
-            markdown_content = " ".join(markdown_content.split()[:MAX_SLM_CONTEXT])
-            logging.warning(f"Truncated markdown content for SLM inference for job {job_id}")
+        original_word_count = len(markdown_content.split())
+        markdown_content, was_sampled = _pkg._sample_for_slm_context(markdown_content, MAX_SLM_CONTEXT)
+        if was_sampled:
+            logging.info(
+                f"Sampled head+tail content for SLM inference for job {job_id} "
+                f"({original_word_count} words -> ~{MAX_SLM_CONTEXT})"
+            )
 
         prompt = (
             "You are a helpful assistant that extracts structured information from documents. "


### PR DESCRIPTION
## Summary
- `extract_slm_metadata` truncated to the first `max_slm_context` (2000) words before SLM extraction, so titles/summaries whose key content appeared later in a long document were never seen.
- Replaces truncation with `_sample_for_slm_context()`: documents at/under the limit pass through unchanged; longer ones are sampled from both head (60%) and tail (40%) of the word budget. Sample size stays fixed regardless of document length, so a single SLM call's latency doesn't grow with document size.

## Test plan
- [x] 5 new tests: short-doc passthrough, exact-limit passthrough, head+tail both present on a long doc, sample size bounded across wildly different document lengths, title-only-in-the-tail case that naive truncation would have missed
- [x] Full `test_worker.py` suite: 88 passed (83 existing + 5 new), no regressions

Story 1.6 (docs/BACKLOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)